### PR TITLE
Add parallel compilation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y build-essential wabt python3
+          sudo apt-get update
+          sudo apt-get install -y build-essential wabt python3
       - name: Build
         run: make ${{ matrix.config }}
       - name: Generate tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function -pthread
+CFLAGS += -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function -pthread
+LDFLAGS += -lm
 
 ifneq (,$(findstring base,$(SANITIZERS)))
 CFLAGS += -fsanitize=undefined
@@ -28,10 +29,10 @@ TEST_OBJECTS = $(patsubst %.c,%.o,$(filter-out main.c,$(wildcard *.c)))
 	$(CC) $(CFLAGS) -c $< -o $@
 
 w2c2: $(TARGET_OBJECTS)
-	$(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 w2c2_test: $(TEST_OBJECTS)
-	$(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
 	-rm -f *.o

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function
+CFLAGS = -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function -pthread
 
 .PHONY: release debug clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
 CFLAGS = -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function -pthread
 
+ifneq (,$(findstring base,$(SANITIZERS)))
+CFLAGS += -fsanitize=undefined
+endif
+ifneq (,$(findstring clang,$(SANITIZERS)))
+CFLAGS += -fsanitize=integer -fsanitize=implicit-conversion
+endif
+ifneq (,$(findstring address,$(SANITIZERS)))
+CFLAGS += -fsanitize=address
+endif
+ifneq (,$(findstring thread,$(SANITIZERS)))
+CFLAGS += -fsanitize=thread
+endif
+
 .PHONY: release debug clean
 
 release: CFLAGS += -O3
 release: w2c2
 
-debug: CFLAGS += -g -O0 -fsanitize=undefined -fsanitize=integer -fsanitize=implicit-conversion -fsanitize=address
+debug: CFLAGS += -g -O0
 debug: w2c2
 
 TARGET_OBJECTS = $(patsubst %.c,%.o,$(filter-out %_test.c test.c,$(wildcard *.c)))

--- a/c.c
+++ b/c.c
@@ -422,7 +422,7 @@ wasmCGetReturnType(
         }
         default:
             /* TODO: add support for multiple result values */
-            fprintf(stderr, "ERROR: function with multiple result values\n");
+            fprintf(stderr, "w2c2: unsupported function with multiple result values\n");
             abort();
     }
 }
@@ -547,7 +547,7 @@ wasmCWriteCallExpr(
     if (!wasmCallInstructionRead(writer->code, opcode, &instruction)) {
         fprintf(
             stderr,
-            "ERROR: invalid %s instruction encoding\n",
+            "w2c2: invalid %s instruction encoding\n",
             wasmOpcodeDescription(opcode)
         );
         return false;
@@ -643,7 +643,7 @@ wasmCWriteCallIndirectExpr(
     if (!wasmCallIndirectInstructionRead(writer->code, opcode, &instruction)) {
         fprintf(
             stderr,
-            "ERROR: invalid %s instruction encoding\n",
+            "w2c2: invalid %s instruction encoding\n",
             wasmOpcodeDescription(opcode)
         );
         return false;
@@ -732,7 +732,7 @@ wasmCWriteLocalGetExpr(
     if (!wasmLocalInstructionRead(writer->code, opcode, &instruction)) {
         fprintf(
             stderr,
-            "ERROR: invalid %s instruction encoding\n",
+            "w2c2: invalid %s instruction encoding\n",
             wasmOpcodeDescription(opcode)
         );
         return false;
@@ -749,7 +749,7 @@ wasmCWriteLocalGetExpr(
         if (!gotType) {
             fprintf(
                 stderr,
-                "ERROR: invalid %s instruction: invalid local index: %u\n",
+                "w2c2: invalid %s instruction: invalid local index: %u\n",
                 wasmOpcodeDescription(opcode),
                 instruction.localIndex
             );
@@ -782,7 +782,7 @@ wasmCWriteLocalAssignmentExpr(
     if (!wasmLocalInstructionRead(writer->code, opcode, &instruction)) {
         fprintf(
             stderr,
-            "ERROR: invalid %s instruction encoding\n",
+            "w2c2: invalid %s instruction encoding\n",
             wasmOpcodeDescription(opcode)
         );
         return false;
@@ -799,7 +799,7 @@ wasmCWriteLocalAssignmentExpr(
         if (!gotType) {
             fprintf(
                 stderr,
-                "ERROR: invalid %s instruction: invalid local index: %u\n",
+                "w2c2: invalid %s instruction: invalid local index: %u\n",
                 wasmOpcodeDescription(opcode),
                 instruction.localIndex
             );
@@ -835,7 +835,7 @@ wasmCWriteGlobalGetExpr(
     if (!wasmGlobalInstructionRead(writer->code, opcode, &instruction)) {
         fprintf(
             stderr,
-            "ERROR: invalid %s instruction encoding\n",
+            "w2c2: invalid %s instruction encoding\n",
             wasmOpcodeDescription(opcode)
         );
         return false;
@@ -851,7 +851,7 @@ wasmCWriteGlobalGetExpr(
         if (!gotType) {
             fprintf(
                 stderr,
-                "ERROR: invalid %s instruction: invalid global index: %u\n",
+                "w2c2: invalid %s instruction: invalid global index: %u\n",
                 wasmOpcodeDescription(opcode),
                 instruction.globalIndex
             );
@@ -884,7 +884,7 @@ wasmCWriteGlobalSetExpr(
     if (!wasmGlobalInstructionRead(writer->code, opcode, &instruction)) {
         fprintf(
             stderr,
-            "ERROR: invalid %s instruction encoding\n",
+            "w2c2: invalid %s instruction encoding\n",
             wasmOpcodeDescription(opcode)
         );
         return false;
@@ -900,7 +900,7 @@ wasmCWriteGlobalSetExpr(
         if (!gotType) {
             fprintf(
                 stderr,
-                "ERROR: invalid %s instruction: invalid global index: %u\n",
+                "w2c2: invalid %s instruction: invalid global index: %u\n",
                 wasmOpcodeDescription(opcode),
                 instruction.globalIndex
             );
@@ -982,7 +982,7 @@ wasmCWriteLiteral(
             break;
         }
         default:
-            fprintf(stderr, "ERROR: unsupported const type %s\n", wasmValueTypeDescription(valueType));
+            fprintf(stderr, "w2c2: unsupported const type %s\n", wasmValueTypeDescription(valueType));
             return false;
     }
 
@@ -998,7 +998,7 @@ wasmCWriteConstExpr(
 ) {
     WasmConstInstruction instruction;
     if (!wasmConstInstructionRead(writer->code, opcode, &instruction)) {
-        fprintf(stderr, "ERROR: invalid const instruction\n");
+        fprintf(stderr, "w2c2: invalid const instruction\n");
         return false;
     }
 
@@ -1028,7 +1028,7 @@ wasmCWriteLoadExpr(
 ) {
     WasmLoadStoreInstruction instruction;
     if (!wasmLoadStoreInstructionRead(writer->code, opcode, &instruction)) {
-        fprintf(stderr, "ERROR: invalid load instruction\n");
+        fprintf(stderr, "w2c2: invalid load instruction\n");
         return false;
     }
 
@@ -1095,7 +1095,7 @@ wasmCWriteLoadExpr(
             default: {
                 fprintf(
                     stderr,
-                    "ERROR: unsupported load instruction opcode: %s\n",
+                    "w2c2: unsupported load instruction opcode: %s\n",
                     wasmOpcodeDescription(opcode)
                 );
                 return false;
@@ -1144,7 +1144,7 @@ wasmCWriteStoreExpr(
 ) {
     WasmLoadStoreInstruction instruction;
     if (!wasmLoadStoreInstructionRead(writer->code, opcode, &instruction)) {
-        fprintf(stderr, "ERROR: invalid store instruction\n");
+        fprintf(stderr, "w2c2: invalid store instruction\n");
         return false;
     }
 
@@ -1191,7 +1191,7 @@ wasmCWriteStoreExpr(
             default: {
                 fprintf(
                     stderr,
-                    "ERROR: unsupported store instruction opcode: %s\n",
+                    "w2c2: unsupported store instruction opcode: %s\n",
                     wasmOpcodeDescription(opcode)
                 );
                 return false;
@@ -1242,7 +1242,7 @@ wasmCWriteMemorySize(
 ) {
     WasmMemoryInstruction instruction;
     if (!wasmMemoryInstructionRead(writer->code, opcode, &instruction)) {
-        fprintf(stderr, "ERROR: invalid memory instruction\n");
+        fprintf(stderr, "w2c2: invalid memory instruction\n");
         return false;
     }
 
@@ -1251,7 +1251,7 @@ wasmCWriteMemorySize(
         if (instruction.memoryIndex != expectedMemoryIndex) {
             fprintf(
                 stderr,
-                "ERROR: invalid memory instruction: expected memory index %u, got %u\n",
+                "w2c2: invalid memory instruction: expected memory index %u, got %u\n",
                 expectedMemoryIndex,
                 instruction.memoryIndex
             );
@@ -1287,7 +1287,7 @@ wasmCWriteMemoryGrow(
 ) {
     WasmMemoryInstruction instruction;
     if (!wasmMemoryInstructionRead(writer->code, opcode, &instruction)) {
-        fprintf(stderr, "ERROR: invalid memory instruction\n");
+        fprintf(stderr, "w2c2: invalid memory instruction\n");
         return false;
     }
 
@@ -1296,7 +1296,7 @@ wasmCWriteMemoryGrow(
         if (instruction.memoryIndex != expectedMemoryIndex) {
             fprintf(
                 stderr,
-                "ERROR: invalid memory instruction: expected memory index %u, got %u\n",
+                "w2c2: invalid memory instruction: expected memory index %u, got %u\n",
                 expectedMemoryIndex,
                 instruction.memoryIndex
             );
@@ -1649,7 +1649,7 @@ wasmCWriteIfExpr(
     WasmValueType blockValueType;
     WasmValueType* blockType = &blockValueType;
     if (!wasmReadBlockType(writer->code, &blockType)) {
-        fprintf(stderr, "ERROR: invalid if instruction: expected block type\n");
+        fprintf(stderr, "w2c2: invalid if instruction: expected block type\n");
         return false;
     }
 
@@ -1744,7 +1744,7 @@ wasmCWriteBlockExpr(
     WasmValueType blockValueType;
     WasmValueType* blockType = &blockValueType;
     if (!wasmReadBlockType(writer->code, &blockType)) {
-        fprintf(stderr, "ERROR: invalid block instruction: expected block type\n");
+        fprintf(stderr, "w2c2: invalid block instruction: expected block type\n");
         return false;
     }
 
@@ -1803,7 +1803,7 @@ wasmCWriteLoopExpr(
     WasmValueType blockValueType;
     WasmValueType* blockType = &blockValueType;
     if (!wasmReadBlockType(writer->code, &blockType)) {
-        fprintf(stderr, "ERROR: invalid loop instruction: expected block type\n");
+        fprintf(stderr, "w2c2: invalid loop instruction: expected block type\n");
         return false;
     }
 
@@ -1945,7 +1945,7 @@ wasmCWriteBranchExpr(
     if (!wasmBranchInstructionRead(writer->code, opcode, &instruction)) {
         fprintf(
             stderr,
-            "ERROR: invalid %s instruction encoding\n",
+            "w2c2: invalid %s instruction encoding\n",
             wasmOpcodeDescription(opcode)
         );
         return false;
@@ -1970,7 +1970,7 @@ wasmCWriteBranchIfExpr(
     if (!wasmBranchInstructionRead(writer->code, opcode, &instruction)) {
         fprintf(
             stderr,
-            "ERROR: invalid %s instruction encoding\n",
+            "w2c2: invalid %s instruction encoding\n",
             wasmOpcodeDescription(opcode)
         );
         return false;
@@ -2016,7 +2016,7 @@ wasmCWriteBranchTableExpr(
     if (!wasmBranchTableInstructionRead(writer->code, opcode, &instruction)) {
         fprintf(
             stderr,
-            "ERROR: invalid %s instruction encoding\n",
+            "w2c2: invalid %s instruction encoding\n",
             wasmOpcodeDescription(opcode)
         );
         return false;
@@ -2578,7 +2578,7 @@ wasmCWriteFunctionCode(
                         break;
                     }
                     default:
-                        fprintf(stderr, "ERROR: unsupported opcode %s\n", wasmOpcodeDescription(*opcode));
+                        fprintf(stderr, "w2c2: unsupported opcode %s\n", wasmOpcodeDescription(*opcode));
                         return false;
                 }
             }
@@ -2669,7 +2669,7 @@ wasmCWriteFunctionBody(
         resultType = &functionType.resultTypes[0];
         /* TODO: add support for multiple result values */
         if (functionType.resultCount > 1) {
-            fprintf(stderr, "ERROR: function with multiple return values\n");
+            fprintf(stderr, "w2c2: function with multiple return values\n");
             return false;
         }
     } else {
@@ -2856,7 +2856,7 @@ wasmCWriteConstantExpr(
             WasmValueType resultType = wasmOpcodeResultType(opcode);
             WasmConstInstruction instruction;
             if (!wasmConstInstructionRead(&code, opcode, &instruction)) {
-                fprintf(stderr, "ERROR: invalid const instruction\n");
+                fprintf(stderr, "w2c2: invalid const instruction\n");
                 return false;
             }
             MUST (wasmCWriteLiteral(builder, resultType, instruction.value))
@@ -2869,7 +2869,7 @@ wasmCWriteConstantExpr(
             break;
         }
         default: {
-            fprintf(stderr, "ERROR: invalid init expression instruction %s\n", wasmOpcodeDescription(opcode));
+            fprintf(stderr, "w2c2: invalid init expression instruction %s\n", wasmOpcodeDescription(opcode));
             return false;
         }
     }

--- a/c.c
+++ b/c.c
@@ -3514,7 +3514,7 @@ wasmCWriteModule(
 
     U32 functionCount = module->functions.count;
     U32 functionCountPerJob = roundUp(
-        (U32)ceilf((float)functionCount / jobCount),
+        (U32)ceil((double)functionCount / jobCount),
         functionsPerFile
     );
 

--- a/c.h
+++ b/c.h
@@ -7,8 +7,10 @@
 bool
 WARN_UNUSED_RESULT
 wasmCWriteModule(
-    FILE* file,
-    const WasmModule* module
+    const char* outputPath,
+    const WasmModule* module,
+    U32 jobCount,
+    U32 functionsPerFile
 );
 
 #endif /* W2C2_C_H */

--- a/examples/coremark/Makefile
+++ b/examples/coremark/Makefile
@@ -5,7 +5,7 @@ coremark: coremark.o main.o ../../wasi/wasi.o
 	$(CC) $^ -o coremark $(LDFLAGS)
 
 %.c: %.wasm
-	../../w2c2 $< > $@
+	../../w2c2 -o $@ $<
 
 %.o: %.c
 	$(CC) -I../.. -c $(CFLAGS) $< -o $@

--- a/examples/dino-gba/Makefile
+++ b/examples/dino-gba/Makefile
@@ -19,7 +19,7 @@ dino.elf: dino.o main.o
 dingo.gba: dino.elf
 
 %.c: %.wasm
-	../../w2c2 $< > $@
+	../../w2c2 -o $@ $<
 
 %.o: %.c
 	$(CC) -I../.. $(CFLAGS) -c $< -o $@

--- a/examples/dino-nds/Makefile
+++ b/examples/dino-nds/Makefile
@@ -20,7 +20,7 @@ dino.elf: dino.o main.o
 	$(CC) $^ -o $@ $(LDFLAGS)
 
 %.c: %.wasm
-	../../w2c2 $< > $@
+	../../w2c2 -o $@ $<
 
 %.o: %.c
 	$(CC) -I../.. $(CFLAGS) -c $< -o $@

--- a/examples/dino-sdl1/Makefile
+++ b/examples/dino-sdl1/Makefile
@@ -5,7 +5,7 @@ dino: dino.o main.o
 	$(CC) $^ -o $@ $(LDFLAGS)
 
 %.c: %.wasm
-	../../w2c2 $< > $@
+	../../w2c2 -o $@ $<
 
 %.o: %.c
 	$(CC) -I../.. $(CFLAGS) -c $< -o $@

--- a/examples/dino-sdl2/Makefile
+++ b/examples/dino-sdl2/Makefile
@@ -5,7 +5,7 @@ dino: dino.o main.o
 	$(CC) $^ -o $@ $(LDFLAGS)
 
 %.c: %.wasm
-	../../w2c2 $< > $@
+	../../w2c2 -o $@ $<
 
 %.o: %.c
 	$(CC) -I../.. $(CFLAGS) -c $< -o $@

--- a/examples/rust-wasi/Makefile
+++ b/examples/rust-wasi/Makefile
@@ -5,7 +5,7 @@ rust-wasi: rust-wasi.o main.o ../../wasi/wasi.o
 	$(CC) $^ -o rust-wasi $(LDFLAGS)
 
 %.c: %.wasm
-	../../w2c2 $< > $@
+	../../w2c2 -o $@ $<
 
 %.o: %.c
 	$(CC) -I../.. $(CFLAGS) -c $< -o $@

--- a/main.c
+++ b/main.c
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <unistd.h>
+#include <ctype.h>
 #include "buffer.h"
 #include "file.h"
 #include "reader.h"
@@ -32,20 +34,100 @@ main(
     int argc,
     char* argv[]
 ) {
-    if (argc < 2) {
-        fprintf(stderr, "missing file name\n");
+    U32 jobCount = 1;
+    char* modulePath = NULL;
+    char* outputPath = NULL;
+    U32 functionsPerFile = 10;
+
+    int index;
+    int c;
+
+    opterr = 0;
+
+    while ((c = getopt(argc, argv, "j:o:f:h")) != -1) {
+        switch (c) {
+            case 'j': {
+                jobCount = strtoul(optarg, NULL, 0);
+                break;
+            }
+            case 'o': {
+                outputPath = optarg;
+                break;
+            }
+            case 'f': {
+                functionsPerFile = strtoul(optarg, NULL, 0);
+                break;
+            }
+            case 'h': {
+                fprintf(
+                    stderr,
+                    "usage: w2c2 [options] filename\n\n"
+                    "options:\n"
+                    "  -h         Print this help message\n"
+                    "  -j         Number of jobCount (>1 enables parallel compilation and requires -o)\n"
+                    "  -f         Number of functions per file when parallel compilation is enabled\n"
+                    "  -o PATH    Path for the output file(s), by default use stdout. Required for parallel compilation\n"
+                );
+                return 0;
+            }
+            case '?': {
+                if (optopt == 'o') {
+                    fprintf(stderr, "w2c2: option -%c requires an argument.\n", optopt);
+                }
+                else if (isprint(optopt)) {
+                    fprintf(stderr, "w2c2: unknown option `-%c'.\n", optopt);
+                } else {
+                    fprintf(
+                        stderr,
+                        "w2c2: unknown option character `\\x%x'.\n",
+                        optopt
+                    );
+                }
+                return 1;
+            }
+            default:
+                abort();
+        }
+    }
+
+    index = optind;
+
+    if (index >= argc) {
+        fprintf(stderr, "w2c2: expected filename argument.\nTry '-h' for more information.\n");
         return 1;
     }
 
+    if (jobCount < 1) {
+        fprintf(stderr, "w2c2: expected jobCount >= 1, got %d\n", jobCount);
+        return 1;
+    }
+
+    if (jobCount > 1 && outputPath == NULL) {
+        fprintf(
+            stderr,
+            "w2c2: expected output path argument for parallel compilation.\n"
+            "Try '-h' for more information.\n"
+        );
+        return 1;
+    }
+
+    modulePath = argv[index];
+
     {
         WasmModuleReader wasmModuleReader;
-        if (!readWasmBinary(argv[1], &wasmModuleReader)) {
+        if (!readWasmBinary(modulePath, &wasmModuleReader)) {
             return 1;
         }
 
-        if (!wasmCWriteModule(stdout, wasmModuleReader.module)) {
+        if (jobCount == 1) {
+            functionsPerFile = wasmModuleReader.module->functions.count;
+        }
+
+        if (!wasmCWriteModule(outputPath, wasmModuleReader.module, jobCount, functionsPerFile)) {
+            fprintf(stderr, "w2c2: failed to compile\n");
             return 1;
         }
     }
+
     return 0;
 }

--- a/main.c
+++ b/main.c
@@ -14,13 +14,13 @@ readWasmBinary(
 
     wasmModuleReaderResult->buffer = readFile(path);
     if (wasmModuleReaderResult->buffer.data == NULL) {
-        fprintf(stderr, "failed to read file %s\n", path);
+        fprintf(stderr, "w2c2: failed to read file %s\n", path);
         return false;
     }
 
     wasmModuleRead(wasmModuleReaderResult, &error);
     if (error != NULL) {
-        fprintf(stderr, "failed to read module: %s\n", wasmModuleReaderErrorMessage(error));
+        fprintf(stderr, "w2c2: failed to read module: %s\n", wasmModuleReaderErrorMessage(error));
         return false;
     }
 

--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <getopt.h>
 #include "buffer.h"
 #include "file.h"
 #include "reader.h"

--- a/reader.c
+++ b/reader.c
@@ -1544,7 +1544,7 @@ wasmModuleReadSection(
         }
     }
 
-    fprintf(stderr, "WasmModuleReader: skipping unsupported %s\n", wasmSectionIDDescription(sectionID));
+    fprintf(stderr, "w2c2: skipping unsupported %s\n", wasmSectionIDDescription(sectionID));
 
     bufferSkip(&reader->buffer, sectionSize);
 

--- a/stringbuilder.c
+++ b/stringbuilder.c
@@ -82,7 +82,7 @@ stringBuilderAppendI64(
     StringBuilder* stringBuilder,
     I64 value
 ) {
-    static char buffer[22];
+    char buffer[22];
     size_t length = sprintf(buffer, "%lld", value);
     return stringBuilderAppendSized(stringBuilder, buffer, length);
 }
@@ -92,7 +92,7 @@ stringBuilderAppendF32(
     StringBuilder* stringBuilder,
     F32 value
 ) {
-    static char buffer[32];
+    char buffer[32];
     size_t length = sprintf(buffer, "%.9g", value);
     return stringBuilderAppendSized(stringBuilder, buffer, length);
 }
@@ -102,7 +102,7 @@ stringBuilderAppendF64(
     StringBuilder* stringBuilder,
     F64 value
 ) {
-    static char buffer[32];
+    char buffer[32];
     size_t length = sprintf(buffer, "%.17g", value);
     return stringBuilderAppendSized(stringBuilder, buffer, length);
 }
@@ -112,7 +112,7 @@ stringBuilderAppendCharHex(
     StringBuilder* stringBuilder,
     char value
 ) {
-    static char buffer[3];
+    char buffer[3];
     size_t length = sprintf(buffer, "%02X", value);
     return stringBuilderAppendSized(stringBuilder, buffer, length);
 }
@@ -122,7 +122,7 @@ stringBuilderAppendU32Hex(
     StringBuilder* stringBuilder,
     U32 value
 ) {
-    static char buffer[9];
+    char buffer[9];
     size_t length = sprintf(buffer, "%08X", value);
     return stringBuilderAppendSized(stringBuilder, buffer, length);
 }
@@ -132,7 +132,7 @@ stringBuilderAppendU64Hex(
     StringBuilder* stringBuilder,
     U64 value
 ) {
-    static char buffer[17];
+    char buffer[17];
     size_t length = sprintf(buffer, "%016llX", value);
     return stringBuilderAppendSized(stringBuilder, buffer, length);
 }


### PR DESCRIPTION
Generate code in parallel when the new option `-j` is given. Code is written into separate files, with a fixed number of functions per file, configurable with the new option `-f`. 

The new output path option `-o` can be specified to generate code into a single file when there is one job, and the option must be specified and be a directory when compiling in parallel.

Parallel compilation generates a `decls.h` with all declarations, an `inits.c` file with the initialization code, and one or more '<index>.c' files with the function implementations.