### PR TITLE
Reduce output size

### DIFF
--- a/c.c
+++ b/c.c
@@ -558,6 +558,32 @@ wasmCWriteAssign(
 }
 
 static
+__inline__
+bool
+WARN_UNUSED_RESULT
+wasmCWriteComma(
+    WasmCFunctionWriter* writer
+) {
+    return wasmCWrite(
+        writer,
+        writer->pretty ? ", " : ","
+    );
+}
+
+static
+__inline__
+bool
+WARN_UNUSED_RESULT
+wasmCWritePlus(
+    WasmCFunctionWriter* writer
+) {
+    return wasmCWrite(
+        writer,
+        writer->pretty ? " + " : "+"
+    );
+}
+
+static
 bool
 WARN_UNUSED_RESULT
 wasmCWriteFunctionCode(
@@ -617,7 +643,7 @@ wasmCWriteCallExpr(
                         parameterCount - parameterIndex - 1
                     );
                     if (parameterIndex > 0) {
-                        MUST (wasmCWrite(writer, ", "))
+                        MUST (wasmCWriteComma(writer))
                     }
                     MUST (wasmCWriteStringStackName(writer->builder, paramStackIndex, parameterType))
                 }
@@ -651,7 +677,7 @@ wasmCWriteParameters(
         for (; parameterIndex < functionType.parameterCount; parameterIndex++) {
             const WasmValueType parameterType = functionType.parameterTypes[parameterIndex];
             if (parameterIndex > 0) {
-                MUST (wasmCWrite(writer, ", "))
+                MUST (wasmCWriteComma(writer))
             }
             MUST (wasmCWrite(writer, valueTypeNames[parameterType]))
         }
@@ -702,7 +728,7 @@ wasmCWriteCallIndirectExpr(
 
         MUST (wasmCWrite(writer, "TF("))
         MUST (wasmCWriteStringTableName(writer->builder, writer->module, instruction.tableIndex, false))
-        MUST (wasmCWrite(writer, ", "))
+        MUST (wasmCWriteComma(writer))
 
         {
             const U32 stackIndex0 = wasmTypeStackGetTopIndex(writer->typeStack, 0);
@@ -713,7 +739,7 @@ wasmCWriteCallIndirectExpr(
             ))
         }
 
-        MUST (wasmCWrite(writer, ", "))
+        MUST (wasmCWriteComma(writer))
         MUST (wasmCWrite(writer, wasmCGetReturnType(functionType)))
         MUST (wasmCWrite(writer, " (*)"))
 
@@ -730,7 +756,7 @@ wasmCWriteCallIndirectExpr(
                     parameterCount - parameterIndex
                 );
                 if (parameterIndex > 0) {
-                    MUST (wasmCWrite(writer, ", "))
+                    MUST (wasmCWriteComma(writer))
                 }
                 MUST (wasmCWriteStringStackName(writer->builder, paramStackIndex, parameterType))
             }
@@ -1141,7 +1167,8 @@ wasmCWriteLoadExpr(
             MUST (wasmCWrite(writer, functionName))
             MUST (wasmCWrite(writer, "("))
             MUST (wasmCWriteStringMemoryName(writer->builder, writer->module, 0, true))
-            MUST (wasmCWrite(writer, ", (U64)("))
+            MUST (wasmCWriteComma(writer))
+            MUST (wasmCWrite(writer, "(U64)("))
             MUST (wasmCWriteStringStackName(
                 writer->builder,
                 stackIndex0,
@@ -1149,7 +1176,7 @@ wasmCWriteLoadExpr(
             ))
             MUST (wasmCWrite(writer, ")"))
             if (instruction.offset != 0) {
-                MUST (wasmCWrite(writer, " + "))
+                MUST (wasmCWritePlus(writer))
                 MUST (stringBuilderAppendI64(writer->builder, (I64) instruction.offset))
                 MUST (wasmCWrite(writer, "u"))
             }
@@ -1235,7 +1262,8 @@ wasmCWriteStoreExpr(
             MUST (wasmCWrite(writer, functionName))
             MUST (wasmCWrite(writer, "("))
             MUST (wasmCWriteStringMemoryName(writer->builder, writer->module, 0, true))
-            MUST (wasmCWrite(writer, ", (U64)("))
+            MUST (wasmCWriteComma(writer))
+            MUST (wasmCWrite(writer, "(U64)("))
             MUST (wasmCWriteStringStackName(
                 writer->builder,
                 stackIndex1,
@@ -1243,11 +1271,11 @@ wasmCWriteStoreExpr(
             ))
             MUST (wasmCWrite(writer, ")"))
             if (instruction.offset != 0) {
-                MUST (wasmCWrite(writer, " + "))
+                MUST (wasmCWritePlus(writer))
                 MUST (stringBuilderAppendI64(writer->builder, (I64) instruction.offset))
                 MUST (wasmCWrite(writer, "u"))
             }
-            MUST (wasmCWrite(writer, ", "))
+            MUST (wasmCWriteComma(writer))
             MUST (wasmCWriteStringStackName(
                 writer->builder,
                 stackIndex0,
@@ -1342,9 +1370,10 @@ wasmCWriteMemoryGrow(
 
             MUST (wasmCWriteIndent(writer))
             MUST (wasmCWriteStringStackName(writer->builder, stackIndex0, resultType))
-            MUST (wasmCWrite(writer, " = wasmGrowMemory("))
+            MUST (wasmCWriteAssign(writer))
+            MUST (wasmCWrite(writer, "wasmGrowMemory("))
             MUST (wasmCWriteStringMemoryName(writer->builder, writer->module, 0, true))
-            MUST (wasmCWrite(writer, ", "))
+            MUST (wasmCWriteComma(writer))
             MUST (wasmCWriteStringStackName(
                 writer->builder,
                 stackIndex0,
@@ -1513,7 +1542,7 @@ wasmCWritePrefixBinaryExpr(
         stackIndex1,
         writer->typeStack->valueTypes[stackIndex1]
     ))
-    MUST (wasmCWrite(writer, ", "))
+    MUST (wasmCWriteComma(writer))
     MUST (wasmCWriteStringStackName(
         writer->builder,
         stackIndex0,

--- a/c.c
+++ b/c.c
@@ -545,6 +545,19 @@ wasmCWrite(
 }
 
 static
+__inline__
+bool
+WARN_UNUSED_RESULT
+wasmCWriteAssign(
+    WasmCFunctionWriter* writer
+) {
+    return wasmCWrite(
+        writer,
+        writer->pretty ? " = " : "="
+    );
+}
+
+static
 bool
 WARN_UNUSED_RESULT
 wasmCWriteFunctionCode(
@@ -589,7 +602,7 @@ wasmCWriteCallExpr(
 
                 MUST (wasmTypeStackSet(writer->stackDeclarations, resultStackIndex, resultType))
                 MUST (wasmCWriteStringStackName(writer->builder, resultStackIndex, resultType))
-                MUST (wasmCWrite(writer, " = "))
+                MUST (wasmCWriteAssign(writer))
             }
 
             MUST (wasmCWriteStringFunctionName(writer->builder, writer->module, instruction.funcIndex, false))
@@ -684,7 +697,7 @@ wasmCWriteCallIndirectExpr(
 
             MUST (wasmTypeStackSet(writer->stackDeclarations, resultStackIndex, resultType))
             MUST (wasmCWriteStringStackName(writer->builder, resultStackIndex, resultType))
-            MUST (wasmCWrite(writer, " = "))
+            MUST (wasmCWriteAssign(writer))
         }
 
         MUST (wasmCWrite(writer, "TF("))
@@ -778,7 +791,7 @@ wasmCWriteLocalGetExpr(
 
             MUST (wasmCWriteIndent(writer))
             MUST (wasmCWriteStringStackName(writer->builder, stackIndex0, localType))
-            MUST (wasmCWrite(writer, " = "))
+            MUST (wasmCWriteAssign(writer))
             MUST (wasmCWriteStringLocalName(writer->builder, instruction.localIndex))
             MUST (wasmCWrite(writer, ";\n"))
         }
@@ -827,7 +840,7 @@ wasmCWriteLocalAssignmentExpr(
 
             MUST (wasmCWriteIndent(writer))
             MUST (wasmCWriteStringLocalName(writer->builder, instruction.localIndex))
-            MUST (wasmCWrite(writer, "="))
+            MUST (wasmCWriteAssign(writer))
             MUST (wasmCWriteStringStackName(writer->builder, stackIndex0, localType))
             MUST (wasmCWrite(writer, ";\n"))
         }
@@ -880,7 +893,7 @@ wasmCWriteGlobalGetExpr(
 
             MUST (wasmCWriteIndent(writer))
             MUST (wasmCWriteStringStackName(writer->builder, stackIndex0, globalType))
-            MUST (wasmCWrite(writer, " = "))
+            MUST (wasmCWriteAssign(writer))
             MUST (wasmCWriteStringGlobalName(writer->builder, writer->module, instruction.globalIndex, false))
             MUST (wasmCWrite(writer, ";\n"))
         }
@@ -928,7 +941,7 @@ wasmCWriteGlobalSetExpr(
 
             MUST (wasmCWriteIndent(writer))
             MUST (wasmCWriteStringGlobalName(writer->builder, writer->module, instruction.globalIndex, false))
-            MUST (wasmCWrite(writer, " = "))
+            MUST (wasmCWriteAssign(writer))
             MUST (wasmCWriteStringStackName(writer->builder, stackIndex0, globalType))
             MUST (wasmCWrite(writer, ";\n"))
         }
@@ -1026,7 +1039,7 @@ wasmCWriteConstExpr(
             MUST (wasmTypeStackSet(writer->stackDeclarations, stackIndex0, resultType))
             MUST (wasmCWriteIndent(writer))
             MUST (wasmCWriteStringStackName(writer->builder, stackIndex0, resultType))
-            MUST (wasmCWrite(writer, " = "))
+            MUST (wasmCWriteAssign(writer))
             MUST (wasmCWriteLiteral(writer->builder, resultType, instruction.value))
             MUST (wasmCWrite(writer, ";\n"))
         }
@@ -1124,7 +1137,7 @@ wasmCWriteLoadExpr(
             MUST (wasmTypeStackSet(writer->stackDeclarations, stackIndex0, resultType))
             MUST (wasmCWriteIndent(writer))
             MUST (wasmCWriteStringStackName(writer->builder, stackIndex0, resultType))
-            MUST (wasmCWrite(writer, " = "))
+            MUST (wasmCWriteAssign(writer))
             MUST (wasmCWrite(writer, functionName))
             MUST (wasmCWrite(writer, "("))
             MUST (wasmCWriteStringMemoryName(writer->builder, writer->module, 0, true))
@@ -1285,7 +1298,7 @@ wasmCWriteMemorySize(
 
             MUST (wasmCWriteIndent(writer))
             MUST (wasmCWriteStringStackName(writer->builder, stackIndex0, resultType))
-            MUST (wasmCWrite(writer, " = "))
+            MUST (wasmCWriteAssign(writer))
             MUST (wasmCWriteStringMemoryName(writer->builder, writer->module, 0, false))
             MUST (wasmCWrite(writer, ".pages;\n"))
         }
@@ -1360,7 +1373,7 @@ wasmCWriteUnaryExpr(
 
     MUST (wasmCWriteIndent(writer))
     MUST (wasmCWriteStringStackName(writer->builder, stackIndex0, resultType))
-    MUST (wasmCWrite(writer, " = "))
+    MUST (wasmCWriteAssign(writer))
     MUST (wasmCWrite(writer, operator))
     MUST (wasmCWrite(writer, "("))
     MUST (wasmCWriteStringStackName(
@@ -1396,11 +1409,16 @@ wasmCWriteInfixBinaryExpr(
     MUST (wasmCWriteStringStackName(writer->builder, stackIndex1, resultType))
 
     if (assignmentAllowed) {
-        MUST (wasmCWrite(writer, " "))
+        if (writer->pretty) {
+            MUST (wasmCWrite(writer, " "))
+        }
         MUST (wasmCWrite(writer, operator))
-        MUST (wasmCWrite(writer, "= "))
+        MUST (wasmCWrite(writer, "="))
+        if (writer->pretty) {
+            MUST (wasmCWrite(writer, " "))
+        }
     } else {
-        MUST (wasmCWrite(writer, " = "))
+        MUST (wasmCWriteAssign(writer))
         MUST (wasmCWriteStringStackName(
             writer->builder,
             stackIndex1,
@@ -1487,7 +1505,7 @@ wasmCWritePrefixBinaryExpr(
 
     MUST (wasmCWriteIndent(writer))
     MUST (wasmCWriteStringStackName(writer->builder, stackIndex1, resultType))
-    MUST (wasmCWrite(writer, " = "))
+    MUST (wasmCWriteAssign(writer))
     MUST (wasmCWrite(writer, operator))
     MUST (wasmCWrite(writer, "("))
     MUST (wasmCWriteStringStackName(
@@ -1889,7 +1907,7 @@ wasmCWriteGoto(
             MUST (wasmTypeStackSet(writer->stackDeclarations, destinationStackIndex, resultType))
 
             MUST (wasmCWriteStringStackName(writer->builder, destinationStackIndex, resultType))
-            MUST (wasmCWrite(writer, " = "))
+            MUST (wasmCWriteAssign(writer))
             MUST (wasmCWriteStringStackName(
                 writer->builder,
                 stackIndex0,
@@ -1926,7 +1944,7 @@ wasmCWriteSelectExpr(
         stackIndex2,
         resultType
     ))
-    MUST (wasmCWrite(writer, " = "))
+    MUST (wasmCWriteAssign(writer))
     MUST (wasmCWriteStringStackName(
         writer->builder,
         stackIndex0,

--- a/c.c
+++ b/c.c
@@ -446,9 +446,9 @@ wasmCWriteFileFunctionSignature(
         module->functionTypes.functionTypes[function.functionTypeIndex];
 
     fputs(wasmCGetReturnType(functionType), file);
-    fputs(" ", file);
+    fputc(' ', file);
     wasmCWriteFileFunctionName(file, module, functionIndex, false);
-    fputs("(", file);
+    fputc('(', file);
     {
         U32 parameterIndex = 0;
         for (; parameterIndex < functionType.parameterCount; parameterIndex++) {
@@ -464,7 +464,7 @@ wasmCWriteFileFunctionSignature(
             }
         }
     }
-    fputs(")", file);
+    fputc(')', file);
 }
 
 static
@@ -488,7 +488,7 @@ wasmCWriteFileLocalsDeclarations(
         for (; localIndex < endIndex; localIndex++) {
             fputs("    ", file);
             fputs(valueTypeNames[localsDeclaration.type], file);
-            fputs(" ", file);
+            fputc(' ', file);
             wasmCWriteFileLocalName(file, parameterCount + localIndex);
             fputs(" = 0;\n", file);
         }
@@ -2611,7 +2611,7 @@ wasmCWriteStackDeclarations(
                 }
                 fputs("    ", file);
                 fputs(valueTypeNames[testType], file);
-                fputs(" ", file);
+                fputc(' ', file);
                 wasmCWriteFileStackName(file, stackDeclarationIndex, testType);
                 fputs(";\n", file);
             }
@@ -2719,7 +2719,7 @@ wasmCWriteFileParameters(
     FILE* file,
     WasmFunctionType functionType
 ) {
-    fputs("(", file);
+    fputc('(', file);
     {
         U32 parameterIndex = 0;
         for (; parameterIndex < functionType.parameterCount; parameterIndex++) {
@@ -2733,7 +2733,7 @@ wasmCWriteFileParameters(
             }
         }
     }
-    fputs(")", file);
+    fputc(')', file);
 }
 
 static
@@ -2841,7 +2841,7 @@ wasmCWriteGlobals(
             fputc(' ', file);
         }
         fputs(valueTypeNames[global.type.valueType], file);
-        fputs(" ", file);
+        fputc(' ', file);
         wasmCWriteFileGlobalName(file, module, module->globalImports.length + globalIndex, false);
         fputs(";\n\n", file);
     }
@@ -2944,7 +2944,7 @@ wasmCWriteFunctionExport(
     fputs(wasmCGetReturnType(functionType), file);
     fputs(" (*", file);
     wasmCWriteExportName(file, export.name);
-    fputs(")", file);
+    fputc(')', file);
     wasmCWriteFileParameters(file, functionType);
     fputs(";\n\n", file);
 }

--- a/c.h
+++ b/c.h
@@ -10,7 +10,8 @@ wasmCWriteModule(
     const char* outputPath,
     const WasmModule* module,
     U32 jobCount,
-    U32 functionsPerFile
+    U32 functionsPerFile,
+    bool pretty
 );
 
 #endif /* W2C2_C_H */

--- a/main.c
+++ b/main.c
@@ -39,13 +39,14 @@ main(
     char* modulePath = NULL;
     char* outputPath = NULL;
     U32 functionsPerFile = 10;
+    bool pretty = false;
 
     int index;
     int c;
 
     opterr = 0;
 
-    while ((c = getopt(argc, argv, "j:o:f:h")) != -1) {
+    while ((c = getopt(argc, argv, "j:o:f:ph")) != -1) {
         switch (c) {
             case 'j': {
                 jobCount = strtoul(optarg, NULL, 0);
@@ -59,6 +60,10 @@ main(
                 functionsPerFile = strtoul(optarg, NULL, 0);
                 break;
             }
+            case 'p': {
+                pretty = true;
+                break;
+            }
             case 'h': {
                 fprintf(
                     stderr,
@@ -68,6 +73,7 @@ main(
                     "  -j         Number of jobCount (>1 enables parallel compilation and requires -o)\n"
                     "  -f         Number of functions per file when parallel compilation is enabled\n"
                     "  -o PATH    Path for the output file(s), by default use stdout. Required for parallel compilation\n"
+                    "  -p         Generate pretty code\n"
                 );
                 return 0;
             }
@@ -124,7 +130,7 @@ main(
             functionsPerFile = wasmModuleReader.module->functions.count;
         }
 
-        if (!wasmCWriteModule(outputPath, wasmModuleReader.module, jobCount, functionsPerFile)) {
+        if (!wasmCWriteModule(outputPath, wasmModuleReader.module, jobCount, functionsPerFile, pretty)) {
             fprintf(stderr, "w2c2: failed to compile\n");
             return 1;
         }


### PR DESCRIPTION
Reduce the size of the generated code by:

- Omitting the parameter names in function declarations
- Removing whitespace (e.g. indentation, space between operators)
- Compressing stack variable declarations in function implementations

For `clang.wasm` this optimization reduces the size from 1.3 GiB to 159MiB.