### PR TITLE
Windows, WASI targets support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential wabt python3
       - name: Build
-        run: make ${{ matrix.config }}
+        run: make BUILD=${{ matrix.config }}
       - name: Generate tests
         working-directory: ./tests
         run: make gen

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,35 @@
 BUILD := release
 
 ifeq ($(OS),Windows_NT)
-    UNAME := Windows
-else
-    UNAME := $(shell uname -s)
+	UNAME := Windows
+endif
+ifdef WASI_CC
+	UNAME := WASI
+	CC    := $(WASI_CC)
+endif
+ifndef UNAME
+	UNAME := $(shell uname -s)
 endif
 
 ifeq ($(BUILD),release)
-    CFLAGS += -O3
+	CFLAGS += -O3
 else
-    CFLAGS += -g -O0
+	CFLAGS += -g -O0
 endif
 
 CFLAGS += -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function
 
 ifeq ($(UNAME),Windows)
-    OUTPUT  := w2c2.exe
-	CC 		:= clang
+	OUTPUT  := w2c2.exe
+	CC      := clang
 	CFLAGS  += -D_CRT_SECURE_NO_WARNINGS
 endif
 ifeq ($(UNAME),WASI)
-    OUTPUT  := w2c2.wasm
+	OUTPUT  := w2c2.wasm
 endif
 
 ifndef OUTPUT
-    OUTPUT  := w2c2
+	OUTPUT  := w2c2
 	CFLAGS  += -pthread -DHAS_PTHREAD
 	LDFLAGS += -lm
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,33 @@
-CFLAGS += -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function -pthread
-LDFLAGS += -lm
+BUILD := release
+
+ifeq ($(OS),Windows_NT)
+    UNAME := Windows
+else
+    UNAME := $(shell uname -s)
+endif
+
+ifeq ($(BUILD),release)
+    CFLAGS += -O3
+else
+    CFLAGS += -g -O0
+endif
+
+CFLAGS += -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function
+
+ifeq ($(UNAME),Windows)
+    OUTPUT  := w2c2.exe
+	CC 		:= clang
+	CFLAGS  += -D_CRT_SECURE_NO_WARNINGS
+endif
+ifeq ($(UNAME),WASI)
+    OUTPUT  := w2c2.wasm
+endif
+
+ifndef OUTPUT
+    OUTPUT  := w2c2
+	CFLAGS  += -pthread -DHAS_PTHREAD
+	LDFLAGS += -lm
+endif
 
 ifneq (,$(findstring base,$(SANITIZERS)))
 CFLAGS += -fsanitize=undefined
@@ -14,13 +42,9 @@ ifneq (,$(findstring thread,$(SANITIZERS)))
 CFLAGS += -fsanitize=thread
 endif
 
-.PHONY: release debug clean
+.PHONY: all clean
 
-release: CFLAGS += -O3
-release: w2c2
-
-debug: CFLAGS += -g -O0
-debug: w2c2
+all: $(OUTPUT)
 
 TARGET_OBJECTS = $(patsubst %.c,%.o,$(filter-out %_test.c test.c,$(wildcard *.c)))
 TEST_OBJECTS = $(patsubst %.c,%.o,$(filter-out main.c,$(wildcard *.c)))
@@ -28,7 +52,7 @@ TEST_OBJECTS = $(patsubst %.c,%.o,$(filter-out main.c,$(wildcard *.c)))
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
-w2c2: $(TARGET_OBJECTS)
+$(OUTPUT): $(TARGET_OBJECTS)
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 w2c2_test: $(TEST_OBJECTS)
@@ -36,4 +60,4 @@ w2c2_test: $(TEST_OBJECTS)
 
 clean:
 	-rm -f *.o
-	-rm -f w2c2 w2c2_test
+	-rm -f $(OUTPUT) w2c2_test

--- a/getopt_impl.h
+++ b/getopt_impl.h
@@ -1,0 +1,72 @@
+#include <string.h>
+#include <stdio.h>
+
+int     opterr = 1,             /* if error message should be printed */
+        optind = 1,             /* index into parent argv vector */
+        optopt,                 /* character checked for validity */
+        optreset;               /* reset getopt */
+char    *optarg;                /* argument associated with option */
+
+#define BADCH   (int)'?'
+#define BADARG  (int)':'
+#define EMSG    ""
+
+/*
+* getopt --
+*      Parse argc/argv argument vector.
+*/
+int
+  getopt(int nargc, char * const nargv[], const char *ostr)
+{
+  static char *place = EMSG;              /* option letter processing */
+  const char *oli;                        /* option letter list index */
+
+  if (optreset || !*place) {              /* update scanning pointer */
+    optreset = 0;
+    if (optind >= nargc || *(place = nargv[optind]) != '-') {
+      place = EMSG;
+      return (-1);
+    }
+    if (place[1] && *++place == '-') {      /* found "--" */
+      ++optind;
+      place = EMSG;
+      return (-1);
+    }
+  }                                       /* option letter okay? */
+  if ((optopt = (int)*place++) == (int)':' ||
+    !(oli = strchr(ostr, optopt))) {
+      /*
+      * if the user didn't specify '-' as an option,
+      * assume it means -1.
+      */
+      if (optopt == (int)'-')
+        return (-1);
+      if (!*place)
+        ++optind;
+      if (opterr && *ostr != ':')
+        (void)printf("illegal option -- %c\n", optopt);
+      return (BADCH);
+  }
+  if (*++oli != ':') {                    /* don't need argument */
+    optarg = NULL;
+    if (!*place)
+      ++optind;
+  }
+  else {                                  /* need an argument */
+    if (*place)                     /* no white space */
+      optarg = place;
+    else if (nargc <= ++optind) {   /* no arg */
+      place = EMSG;
+      if (*ostr == ':')
+        return (BADARG);
+      if (opterr)
+        (void)printf("option requires an argument -- %c\n", optopt);
+      return (BADCH);
+    }
+    else                            /* white space */
+      optarg = nargv[optind];
+    place = EMSG;
+    ++optind;
+  }
+  return (optopt);                        /* dump back option letter */
+}

--- a/getopt_impl.h
+++ b/getopt_impl.h
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 1987, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
 #include <string.h>
 #include <stdio.h>
 

--- a/main.c
+++ b/main.c
@@ -1,7 +1,12 @@
 #include <stdio.h>
-#include <unistd.h>
+#include <stdint.h>
 #include <ctype.h>
-#include <getopt.h>
+#ifdef _WIN32
+  #include "getopt_impl.h"
+#else 
+  #include <getopt.h>
+#endif
+
 #include "buffer.h"
 #include "file.h"
 #include "reader.h"


### PR DESCRIPTION
Following-up the idea in https://github.com/turbolent/w2c2/issues/1#issuecomment-1019954628

- Allow disabling `pthreads`
- Initial Windows target support (no parallel mode + `getopt` impl)
- Initial WASI target support
- Skip creating empty files in parallel mode