### PR TITLE
Optimize data segments

### DIFF
--- a/c.c
+++ b/c.c
@@ -1,9 +1,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <math.h>
-#define HAS_PTHREAD 1
 #if HAS_PTHREAD
   #include <pthread.h>
 #endif

--- a/c.c
+++ b/c.c
@@ -3199,8 +3199,12 @@ wasmCWriteDataSegmentsAsSection(
             fputs("extern char _binary_datasegments_start[];\n\n", file);
             break;
         }
-        case wasmDataSegmentModeNSLD: {
+        case wasmDataSegmentModeSectcreate1: {
             fputs("extern char datasegments __asm(\"section$start$__DATA$__datasegments\");\n\n", file);
+            break;
+        }
+        case wasmDataSegmentModeSectcreate2: {
+            fputs("#include <mach-o/getsect.h>\n\n", file);
             break;
         }
         default: {
@@ -3246,7 +3250,8 @@ wasmCWriteDataSegments(
             break;
         }
         case wasmDataSegmentModeGNULD:
-        case wasmDataSegmentModeNSLD: {
+        case wasmDataSegmentModeSectcreate1:
+        case wasmDataSegmentModeSectcreate2: {
             wasmCWriteDataSegmentsAsSection(file, module, mode, pretty);
             break;
         }
@@ -3309,8 +3314,16 @@ wasmCWriteInitMemories(
             fputs("static char* ds = _binary_datasegments_start;\n", file);
             break;
         }
-        case wasmDataSegmentModeNSLD: {
+        case wasmDataSegmentModeSectcreate1: {
             fputs("static char* ds = &datasegments;\n", file);
+            break;
+        }
+        case wasmDataSegmentModeSectcreate2: {
+            fputs(
+                "unsigned long len = 0;\n"
+                "char* ds = getsectdata(\"__DATA\", \"__datasegments\", &len);\n",
+                file
+            );
             break;
         }
         default:
@@ -3358,7 +3371,8 @@ wasmCWriteInitMemories(
                     break;
                 }
                 case wasmDataSegmentModeGNULD:
-                case wasmDataSegmentModeNSLD: {
+                case wasmDataSegmentModeSectcreate1:
+                case wasmDataSegmentModeSectcreate2: {
                     fprintf(file, "ds + %lu", (unsigned long)dataSegmentOffset);
                     break;
                 }

--- a/c.c
+++ b/c.c
@@ -3831,6 +3831,8 @@ wasmCWriteModuleParallel(
     }
 
     initsJob.module = module;
+    initsJob.dataSegmentMode = options.dataSegmentMode;
+    initsJob.pretty = options.pretty;
 
     declarationsJob.module = module;
     declarationsJob.pretty = options.pretty;

--- a/c.c
+++ b/c.c
@@ -2998,6 +2998,9 @@ wasmCWriteInitGlobals(
 ) {
     U32 globalIndex = 0;
 
+    StringBuilder stringBuilder = emptyStringBuilder;
+    MUST (stringBuilderInitialize(&stringBuilder))
+
     fputs("static void initGlobals(void) {\n", file);
 
     for (; globalIndex < module->globals.count; globalIndex++) {
@@ -3010,17 +3013,17 @@ wasmCWriteInitGlobals(
         fputs(" = ", file);
         {
             Buffer code = global.init;
-            StringBuilder stringBuilder = emptyStringBuilder;
+            MUST (stringBuilderReset(&stringBuilder))
 
-            MUST (stringBuilderInitialize(&stringBuilder))
             MUST (wasmCWriteConstantExpr(&stringBuilder, module, code))
             fputs(stringBuilder.string, file);
-            stringBuilderFree(&stringBuilder);
         }
         fputs(";\n", file);
     }
 
     fputs("}\n\n", file);
+
+    stringBuilderFree(&stringBuilder);
 
     return true;
 }
@@ -3219,6 +3222,9 @@ wasmCWriteInitMemories(
     const WasmModule* module,
     bool pretty
 ) {
+    StringBuilder stringBuilder = emptyStringBuilder;
+    MUST (stringBuilderInitialize(&stringBuilder))
+
     fputs("static void initMemories(void) {\n", file);
 
     {
@@ -3248,12 +3254,10 @@ wasmCWriteInitMemories(
             fputs(", ", file);
             {
                 Buffer code = dataSegment.offset;
-                StringBuilder stringBuilder = emptyStringBuilder;
+                MUST (stringBuilderReset(&stringBuilder))
 
-                MUST (stringBuilderInitialize(&stringBuilder))
                 MUST (wasmCWriteConstantExpr(&stringBuilder, module, code))
                 fputs(stringBuilder.string, file);
-                stringBuilderFree(&stringBuilder);
             }
             fputs(", ", file);
             wasmCWriteFileDataSegmentName(file, dataSegmentIndex);
@@ -3262,6 +3266,8 @@ wasmCWriteInitMemories(
     }
 
     fputs("}\n\n", file);
+
+    stringBuilderFree(&stringBuilder);
 
     return true;
 }
@@ -3307,6 +3313,9 @@ wasmCWriteInitTables(
     const WasmModule* module,
     bool pretty
 ) {
+    StringBuilder stringBuilder = emptyStringBuilder;
+    MUST (stringBuilderInitialize(&stringBuilder))
+
     fputs("static void initTables(void) {\n", file);
 
     if (module->elementSegments.count > 0) {
@@ -3342,12 +3351,9 @@ wasmCWriteInitTables(
             fputs("offset = ", file);
             {
                 Buffer code = elementSegment.offset;
-                StringBuilder stringBuilder = emptyStringBuilder;
-
-                MUST (stringBuilderInitialize(&stringBuilder))
+                MUST (stringBuilderReset(&stringBuilder))
                 MUST (wasmCWriteConstantExpr(&stringBuilder, module, code))
                 fputs(stringBuilder.string, file);
-                stringBuilderFree(&stringBuilder);
             }
             fputs(";\n", file);
 
@@ -3368,6 +3374,8 @@ wasmCWriteInitTables(
     }
 
     fputs("}\n\n", file);
+
+    stringBuilderFree(&stringBuilder);
 
     return true;
 }

--- a/c.h
+++ b/c.h
@@ -9,9 +9,12 @@ typedef struct WasmCWriteModuleOptions {
     U32 jobCount;
     U32 functionsPerFile;
     bool pretty;
+    WasmDataSegmentMode dataSegmentMode;
 } WasmCWriteModuleOptions;
 
-static const WasmCWriteModuleOptions emptyWasmCWriteModuleOptions = {NULL, 1, 1, false};
+static const WasmCWriteModuleOptions emptyWasmCWriteModuleOptions ={
+    NULL, 0, 0, false, wasmDataSegmentModeArrays
+};
 
 bool
 WARN_UNUSED_RESULT

--- a/c.h
+++ b/c.h
@@ -4,14 +4,20 @@
 #include "w2c2_base.h"
 #include "module.h"
 
+typedef struct WasmCWriteModuleOptions {
+    const char* outputPath;
+    U32 jobCount;
+    U32 functionsPerFile;
+    bool pretty;
+} WasmCWriteModuleOptions;
+
+static const WasmCWriteModuleOptions emptyWasmCWriteModuleOptions = {NULL, 1, 1, false};
+
 bool
 WARN_UNUSED_RESULT
 wasmCWriteModule(
-    const char* outputPath,
     const WasmModule* module,
-    U32 jobCount,
-    U32 functionsPerFile,
-    bool pretty
+    WasmCWriteModuleOptions options
 );
 
 #endif /* W2C2_C_H */

--- a/datasegment.h
+++ b/datasegment.h
@@ -15,7 +15,8 @@ static const WasmDataSegment wasmEmptyDataSegment = {0, {0, false}};
 
 typedef enum WasmDataSegmentMode {
     wasmDataSegmentModeArrays,
-    wasmDataSegmentModeGNULD
+    wasmDataSegmentModeGNULD,
+    wasmDataSegmentModeNSLD
 } WasmDataSegmentMode;
 
 #endif /* W2C2_DATASEGMENT_H */

--- a/datasegment.h
+++ b/datasegment.h
@@ -13,4 +13,9 @@ typedef struct WasmDataSegment {
 
 static const WasmDataSegment wasmEmptyDataSegment = {0, {0, false}};
 
+typedef enum WasmDataSegmentMode {
+    wasmDataSegmentModeArrays,
+    wasmDataSegmentModeGNULD
+} WasmDataSegmentMode;
+
 #endif /* W2C2_DATASEGMENT_H */

--- a/datasegment.h
+++ b/datasegment.h
@@ -16,7 +16,8 @@ static const WasmDataSegment wasmEmptyDataSegment = {0, {0, false}};
 typedef enum WasmDataSegmentMode {
     wasmDataSegmentModeArrays,
     wasmDataSegmentModeGNULD,
-    wasmDataSegmentModeNSLD
+    wasmDataSegmentModeSectcreate1,
+    wasmDataSegmentModeSectcreate2
 } WasmDataSegmentMode;
 
 #endif /* W2C2_DATASEGMENT_H */

--- a/examples/clang/Makefile
+++ b/examples/clang/Makefile
@@ -7,7 +7,7 @@ MODE := gnu-ld
 
 ifeq ($(shell uname -s),Darwin)
     # at least Darwin 11 / Mac OS X 10.7 ?
-    ifeq ($(shell test `uname -r | grep -o "^[0-9]"` -gt 10; echo $$?),0)
+    ifeq ($(shell test `uname -r | egrep -o "^[0-9]+"` -gt 10; echo $$?),0)
     MODE = sectcreate1
     else
     MODE = sectcreate2

--- a/examples/clang/Makefile
+++ b/examples/clang/Makefile
@@ -6,7 +6,12 @@ OBJS :=  ../../wasi/wasi.o inits.o
 MODE := gnu-ld
 
 ifeq ($(shell uname -s),Darwin)
-    MODE = ns-ld
+    # at least Darwin 11 / Mac OS X 10.7 ?
+    ifeq ($(shell test `uname -r | grep -o "^[0-9]"` -gt 10; echo $$?),0)
+    MODE = sectcreate1
+    else
+    MODE = sectcreate2
+    endif
     LDFLAGS += -sectcreate __DATA __datasegments datasegments
 else
     OBJS += datasegments.o

--- a/examples/clang/Makefile
+++ b/examples/clang/Makefile
@@ -3,8 +3,10 @@ LDFLAGS += -lm
 W2C2 ?= ../../w2c2
 
 OBJS :=  ../../wasi/wasi.o inits.o
+MODE := gnu-ld
 
 ifeq ($(shell uname -s),Darwin)
+    MODE = ns-ld
     LDFLAGS += -sectcreate __DATA __datasegments datasegments
 else
     OBJS += datasegments.o
@@ -23,7 +25,7 @@ inits.o: CFLAGS += -O0
 	$(CC) -I.. -O3 $(CFLAGS) -c $< -o $@
 
 inits.c: clang.wasm
-	$(W2C2) -d gnu-ld -j 12 -o . -f 100 $^
+	$(W2C2) -d $(MODE) -j 12 -o . -f 100 $^
 
 .PHONY: clean
 clean:

--- a/examples/clang/Makefile
+++ b/examples/clang/Makefile
@@ -2,9 +2,17 @@ CFLAGS += -I../..
 LDFLAGS += -lm
 W2C2 ?= ../../w2c2
 
-clang: ../../wasi/wasi.o inits.o datasegments.o
+OBJS :=  ../../wasi/wasi.o inits.o
+
+ifeq ($(shell uname -s),Darwin)
+    LDFLAGS += -sectcreate __DATA __datasegments datasegments
+else
+    OBJS += datasegments.o
+endif
+
+clang: $(OBJS)
 	$(MAKE) $(patsubst %.c,%.o,$(wildcard *.c))
-	$(CC) $(CFLAGS) $(patsubst %.c,%.o,$(wildcard *.c)) datasegments.o ../../wasi/wasi.o -o clang $(LDFLAGS)
+	$(CC) $(CFLAGS) $(filter-out inits.o, $(patsubst %.c,%.o,$(wildcard *.c))) $(OBJS) -o clang $(LDFLAGS)
 
 datasegments.o: inits.c
 	ld -r -b binary -o datasegments.o datasegments

--- a/examples/clang/Makefile
+++ b/examples/clang/Makefile
@@ -2,9 +2,12 @@ CFLAGS += -I../..
 LDFLAGS += -lm
 W2C2 ?= ../../w2c2
 
-clang: ../../wasi/wasi.o inits.o
+clang: ../../wasi/wasi.o inits.o datasegments.o
 	$(MAKE) $(patsubst %.c,%.o,$(wildcard *.c))
-	$(CC) $(CFLAGS) $(patsubst %.c,%.o,$(wildcard *.c)) ../../wasi/wasi.o -o clang $(LDFLAGS)
+	$(CC) $(CFLAGS) $(patsubst %.c,%.o,$(wildcard *.c)) datasegments.o ../../wasi/wasi.o -o clang $(LDFLAGS)
+
+datasegments.o: inits.c
+	ld -r -b binary -o datasegments.o datasegments
 
 inits.o: CFLAGS += -O0
 
@@ -12,8 +15,8 @@ inits.o: CFLAGS += -O0
 	$(CC) -I.. -O3 $(CFLAGS) -c $< -o $@
 
 inits.c: clang.wasm
-	$(W2C2) -j 12 -o . -f 100 $^
+	$(W2C2) -d gnu-ld -j 12 -o . -f 100 $^
 
 .PHONY: clean
 clean:
-	rm -f clang decls.h $(filter-out main.c,$(wildcard *.c)) *.o
+	rm -f clang datasegments decls.h $(filter-out main.c,$(wildcard *.c)) *.o

--- a/main.c
+++ b/main.c
@@ -75,12 +75,16 @@ main(
                     dataSegmentMode = wasmDataSegmentModeArrays;
                 } else if (strcmp(optarg, "gnu-ld") == 0) {
                     dataSegmentMode = wasmDataSegmentModeGNULD;
+                } else if (strcmp(optarg, "ns-ld") == 0) {
+                    dataSegmentMode = wasmDataSegmentModeNSLD;
                 } else if (strcmp(optarg, "help") == 0) {
                     fprintf(
                         stderr,
                         "Supported data segment modes are:\n"
                         "arrays    Writes each data segment as a C array\n"
-                        "gnu-ld    All data segments are embedded into a section using GNU LD\n"
+                        "gnu-ld    All data segments are embedded into a data section using GNU LD\n"
+                        "ns-ld     All data segments are embedded into a data section using NS LD "
+                        "(NeXTSTEP, OPENSTEP, Darwin/macOS)\n"
                     );
                     return EXIT_SUCCESS;
                 } else {

--- a/main.c
+++ b/main.c
@@ -75,16 +75,20 @@ main(
                     dataSegmentMode = wasmDataSegmentModeArrays;
                 } else if (strcmp(optarg, "gnu-ld") == 0) {
                     dataSegmentMode = wasmDataSegmentModeGNULD;
-                } else if (strcmp(optarg, "ns-ld") == 0) {
-                    dataSegmentMode = wasmDataSegmentModeNSLD;
+                } else if (strcmp(optarg, "sectcreate1") == 0) {
+                    dataSegmentMode = wasmDataSegmentModeSectcreate1;
+                } else if (strcmp(optarg, "sectcreate2") == 0) {
+                    dataSegmentMode = wasmDataSegmentModeSectcreate2;
                 } else if (strcmp(optarg, "help") == 0) {
                     fprintf(
                         stderr,
                         "Supported data segment modes are:\n"
-                        "arrays    Writes each data segment as a C array\n"
-                        "gnu-ld    All data segments are embedded into a data section using GNU LD\n"
-                        "ns-ld     All data segments are embedded into a data section using NS LD "
-                        "(NeXTSTEP, OPENSTEP, Darwin/macOS)\n"
+                        "arrays         Writes each data segment as a C array\n"
+                        "gnu-ld         All data segments are embedded into a data section using GNU LD\n"
+                        "sectcreate1    All data segments are embedded into a data section using sectcreate\n"
+                        "               and accessed using asm (modern Mach-O LD)\n"
+                        "sectcreate2    All data segments are embedded into a data section using sectcreate\n"
+                        "               and accessed using Mach-O getsectdata (older Mach-O LD)\n"
                     );
                     return EXIT_SUCCESS;
                 } else {

--- a/main.c
+++ b/main.c
@@ -126,16 +126,23 @@ main(
     modulePath = argv[index];
 
     {
-        WasmModuleReader wasmModuleReader;
-        if (!readWasmBinary(modulePath, &wasmModuleReader)) {
+        WasmModuleReader reader = emptyWasmModuleReader;
+        WasmCWriteModuleOptions writeOptions = emptyWasmCWriteModuleOptions;
+
+        if (!readWasmBinary(modulePath, &reader)) {
             return 1;
         }
 
         if (jobCount == 1) {
-            functionsPerFile = wasmModuleReader.module->functions.count;
+            functionsPerFile = reader.module->functions.count;
         }
 
-        if (!wasmCWriteModule(outputPath, wasmModuleReader.module, jobCount, functionsPerFile, pretty)) {
+        writeOptions.outputPath = outputPath;
+        writeOptions.jobCount = jobCount;
+        writeOptions.functionsPerFile = functionsPerFile;
+        writeOptions.pretty = pretty;
+
+        if (!wasmCWriteModule(reader.module, writeOptions)) {
             fprintf(stderr, "w2c2: failed to compile\n");
             return 1;
         }

--- a/reader.h
+++ b/reader.h
@@ -10,6 +10,8 @@ typedef struct {
     WasmModule* module;
 } WasmModuleReader;
 
+static const WasmModuleReader emptyWasmModuleReader = {{NULL, 0}, NULL};
+
 typedef enum {
     wasmModuleReaderInvalidMagic,
     wasmModuleReaderAllocationFailed,

--- a/stringbuilder.c
+++ b/stringbuilder.c
@@ -26,7 +26,7 @@ WARN_UNUSED_RESULT
 stringBuilderInitialize(
     StringBuilder* stringBuilder
 ) {
-    static const size_t initialCapacity = sizeof(char);
+    static const size_t initialCapacity = sizeof(char) * 8;
     void* newString = NULL;
     MUST (stringBuilder->string == NULL)
     newString = malloc(initialCapacity);
@@ -35,6 +35,21 @@ stringBuilderInitialize(
     stringBuilder->length = 0;
     stringBuilder->capacity = initialCapacity;
     stringBuilder->string = (char*) newString;
+    stringBuilder->string[0] = '\0';
+
+    return true;
+}
+
+bool
+WARN_UNUSED_RESULT
+stringBuilderReset(
+    StringBuilder* stringBuilder
+) {
+    if (stringBuilder->capacity < 1) {
+        MUST (stringBuilderInitialize(stringBuilder))
+    }
+
+    stringBuilder->length = 0;
     stringBuilder->string[0] = '\0';
 
     return true;

--- a/stringbuilder.h
+++ b/stringbuilder.h
@@ -18,6 +18,12 @@ stringBuilderInitialize(
     StringBuilder* stringBuilder
 );
 
+bool
+WARN_UNUSED_RESULT
+stringBuilderReset(
+    StringBuilder* stringBuilder
+);
+
 void
 stringBuilderFree(
     StringBuilder* stringBuilder


### PR DESCRIPTION
Optimize the compilation of data segments by adding 

Make the data segment compilation configurable, by adding the command line option `-d`. The option `help` lists the available modes:
- `arrays`: Writes each data segment as a C array (default)
- `gnu-ld`: All data segments are embedded into a data section using GNU LD
- `sectcreate1`: All data segments are embedded into a data section using the `sectcreate` option of modern Mach-O LD versions (recent macOS versions) and accessed using an `asm` reference
- `sectcreate2`: All data segments are embedded into a data section using the `sectcreate` option of older Mach-O LD versions (older Mac OS X, OPENSTEP, NeXTSTEP, etc.) and accessed using Mach-O `getsectdata`