### PR TITLE
Add support for parsing DWARF and generating line directives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifeq ($(OS),Windows_NT)
 endif
 ifdef WASI_CC
 	UNAME := WASI
-	CC    := $(WASI_CC)
+	CC := $(WASI_CC)
 endif
 ifndef UNAME
 	UNAME := $(shell uname -s)
@@ -20,20 +20,35 @@ endif
 CFLAGS += -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function
 
 ifeq ($(UNAME),Windows)
-	OUTPUT  := w2c2.exe
-	CC      := clang
-	CFLAGS  += -D_CRT_SECURE_NO_WARNINGS
+	OUTPUT := w2c2.exe
+	CC := clang
+	CFLAGS += -D_CRT_SECURE_NO_WARNINGS
 endif
 ifeq ($(UNAME),WASI)
-	OUTPUT  := w2c2.wasm
+	OUTPUT := w2c2.wasm
 endif
 ifeq ($(UNAME),Linux)
 	LDFLAGS += -lm
+	ifneq (,$(findstring threads,$(FEATURES)))
+	CFLAGS += -pthread
+	endif
+endif
+
+ifneq (,$(findstring threads,$(FEATURES)))
+	CFLAGS += -DHAS_PTHREAD
+endif
+
+ifneq (,$(findstring getopt,$(FEATURES)))
+	CFLAGS += -DHAS_GETOPT
+endif
+
+ifneq (,$(findstring debugging,$(FEATURES)))
+	CFLAGS += -DHAS_LIBDWARF
+	LDFLAGS += -ldwarf
 endif
 
 ifndef OUTPUT
-	OUTPUT  := w2c2
-	CFLAGS  += -pthread -DHAS_PTHREAD -DHAS_GETOPT
+	OUTPUT := w2c2
 endif
 
 ifneq (,$(findstring base,$(SANITIZERS)))

--- a/c.h
+++ b/c.h
@@ -9,6 +9,7 @@ typedef struct WasmCWriteModuleOptions {
     U32 jobCount;
     U32 functionsPerFile;
     bool pretty;
+    bool debug;
     WasmDataSegmentMode dataSegmentMode;
 } WasmCWriteModuleOptions;
 

--- a/debug.c
+++ b/debug.c
@@ -1,0 +1,409 @@
+#include <string.h>
+#include "debug.h"
+#include "buffer.h"
+#include "str.h"
+
+bool
+wasmDebugLinesEnsureCapacity(
+    WasmDebugLines* debugLines,
+    size_t length
+) {
+    if (length > debugLines->capacity) {
+        size_t newCapacity = length + (debugLines->capacity >> 1u);
+        void* newValueTypes = NULL;
+        if (debugLines->debugLines == NULL) {
+            newValueTypes = calloc(newCapacity * sizeof(WasmDebugLine), 1);
+        } else {
+            newValueTypes = realloc(debugLines->debugLines, newCapacity * sizeof(WasmDebugLine));
+        }
+        MUST (newValueTypes != NULL)
+        debugLines->debugLines = (WasmDebugLine*) newValueTypes;
+        debugLines->capacity = newCapacity;
+    }
+    return true;
+}
+
+#if HAS_LIBDWARF
+
+#include <stdio.h>
+#include <libdwarf/libdwarf.h>
+#include <libdwarf/dwarf.h>
+
+static
+int
+dwarfAccessGetSectionInfo(
+    void* obj,
+    Dwarf_Half sectionIndex,
+    Dwarf_Obj_Access_Section* accessSection,
+    int* error
+) {
+    WasmDebugSections* sections = (WasmDebugSections*) obj;
+    WasmDebugSection section = sections->debugSections[sectionIndex];
+
+    accessSection->addr = 0;
+    accessSection->name = section.name;
+    accessSection->size = section.buffer.length;
+    accessSection->info = 0;
+    accessSection->link = 0;
+    accessSection->type = 0;
+    accessSection->entrysize = 0;
+
+    return DW_DLV_OK;
+}
+
+static
+Dwarf_Endianness
+dwarfAccessGetByteOrder(
+    void* obj
+) {
+    return DW_ENDIAN_LITTLE;
+}
+
+static
+Dwarf_Small
+dwarfAccessGetPointerSize(
+    void* obj
+) {
+    return 4;
+}
+
+static
+Dwarf_Small
+dwarfAccessGetLengthSize(
+    void* obj
+) {
+    return 4;
+}
+
+static
+Dwarf_Unsigned
+dwarfAccessGetSectionCount(
+    void* obj
+) {
+    WasmDebugSections* sections = (WasmDebugSections*) obj;
+    return sections->count;
+}
+
+static
+int
+dwarfAccessLoadSection(
+    void* obj,
+    Dwarf_Half sectionIndex,
+    Dwarf_Small** sectionData,
+    int* error
+) {
+    WasmDebugSections* sections = (WasmDebugSections*) obj;
+    WasmDebugSection section = sections->debugSections[sectionIndex];
+
+    *sectionData = section.buffer.data;
+
+    return DW_DLV_OK;
+}
+
+static
+int
+dwarfAccessRelocateASection(
+    void* obj,
+    Dwarf_Half sectionIndex,
+    Dwarf_Debug debug,
+    int* error
+) {
+    return DW_DLV_NO_ENTRY;
+}
+
+static const struct Dwarf_Obj_Access_Methods_s dwarfAccessMethods = {
+    dwarfAccessGetSectionInfo,
+    dwarfAccessGetByteOrder,
+    dwarfAccessGetLengthSize,
+    dwarfAccessGetPointerSize,
+    dwarfAccessGetSectionCount,
+    dwarfAccessLoadSection,
+    dwarfAccessRelocateASection
+};
+
+static
+int
+compareDebugLines(const void *a, const void *b) {
+    WasmDebugLine* l1 = (WasmDebugLine*) a;
+    WasmDebugLine* l2 = (WasmDebugLine*) b;
+    if (l1->address < l2->address) {
+        return -1;
+    } else if (l1->address > l2->address) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+static
+void
+appendSubprogramDebugLine(
+    Dwarf_Die die,
+    char** files,
+    WasmDebugLines* debugLines
+) {
+    int res = DW_DLV_ERROR;
+    Dwarf_Error error = NULL;
+    Dwarf_Addr address = 0;
+    Dwarf_Bool hasDeclLine = false;
+    Dwarf_Bool hasDeclFile = false;
+    Dwarf_Attribute attr = NULL;
+    Dwarf_Unsigned line = 0;
+    Dwarf_Unsigned fileIndex = 0;
+
+    res = dwarf_lowpc(die, &address, &error);
+    if (res != DW_DLV_OK || address >= 0xffffffff) {
+        return;
+    }
+
+    res = dwarf_hasattr(die, DW_AT_decl_line, &hasDeclLine, &error);
+    if (res != DW_DLV_OK || !hasDeclLine) {
+        return;
+    }
+
+    res = dwarf_hasattr(die, DW_AT_decl_file, &hasDeclFile, &error);
+    if (res != DW_DLV_OK || !hasDeclFile) {
+        return;
+    }
+
+    res = dwarf_attr(die, DW_AT_decl_line, &attr, &error);
+    if (res != DW_DLV_OK) {
+        return;
+    }
+
+    res = dwarf_formudata(attr, &line, &error);
+    if (res != DW_DLV_OK) {
+        return;
+    }
+
+    res = dwarf_attr(die, DW_AT_decl_file, &attr, &error);
+    if (res != DW_DLV_OK) {
+        return;
+    }
+
+    res = dwarf_formudata(attr, &fileIndex, &error);
+    if (res != DW_DLV_OK) {
+        return;
+    }
+
+    {
+        WasmDebugLine debugLine = {0, NULL, 0};
+        debugLine.address = address;
+        debugLine.path = strdup(files[fileIndex - 1]);
+        debugLine.number = line;
+
+        if (!wasmDebugLinesPush(debugLines, debugLine)) {
+            /* TODO: bubble up error? */
+        }
+    }
+}
+
+static
+void
+appendSubprogramDebugLines(
+    Dwarf_Debug debug,
+    Dwarf_Die rootDie,
+    char** files,
+    WasmDebugLines* debugLines
+) {
+    int res = DW_DLV_ERROR;
+    Dwarf_Die childDie = NULL;
+    Dwarf_Error error = NULL;
+
+    res = dwarf_child(rootDie, &childDie, &error);
+    switch (res) {
+        case DW_DLV_ERROR: {
+            fprintf(stderr, "w2c2: failed to get child DIE\n");
+            return;
+        }
+        case DW_DLV_NO_ENTRY:
+            return;
+    }
+
+    while (true) {
+        Dwarf_Half childDieTag = 0;
+        Dwarf_Die nextChildDie = NULL;
+
+        res = dwarf_tag(childDie, &childDieTag, &error);
+        if (res != DW_DLV_OK) {
+            fprintf(stderr, "w2c2: failed to get DIE tag\n");
+        }
+
+        if (childDieTag == DW_TAG_subprogram) {
+            appendSubprogramDebugLine(childDie, files, debugLines);
+        }
+
+        if (childDieTag != DW_TAG_base_type
+            && childDieTag != DW_TAG_lexical_block) {
+
+            appendSubprogramDebugLines(debug, childDie, files, debugLines);
+        }
+
+        res = dwarf_siblingof(debug, childDie, &nextChildDie, &error);
+        dwarf_dealloc(debug, childDie, DW_DLA_DIE);
+        childDie = nextChildDie;
+
+        switch (res) {
+            case DW_DLV_ERROR: {
+                fprintf(stderr, "w2c2: failed to get child sibling DIE\n");
+                return;
+            }
+            case DW_DLV_NO_ENTRY:
+                return;
+        }
+    }
+}
+
+WasmDebugLines
+wasmParseDebugInfo(
+    WasmDebugSections sections
+) {
+    WasmDebugLines debugLines = emptyWasmDebugLines;
+    int res = DW_DLV_ERROR;
+    Dwarf_Obj_Access_Interface* interface = NULL;
+    Dwarf_Debug debug;
+    Dwarf_Error error = NULL;
+
+    interface = (Dwarf_Obj_Access_Interface *)calloc(1, sizeof(Dwarf_Obj_Access_Interface*));
+    if (!interface) {
+        fprintf(stderr, "w2c2: failed to allocate DWARF interface\n");
+        goto end;
+    }
+
+    interface->object = &sections;
+    interface->methods = &dwarfAccessMethods;
+
+    res = dwarf_object_init(interface, NULL, NULL, &debug, &error);
+    if (res != DW_DLV_OK) {
+        fprintf(stderr, "w2c2: failed to init DWARF reader\n");
+        goto end;
+    }
+
+    while (true) {
+        Dwarf_Die cuDie = NULL;
+        Dwarf_Half tag = 0;
+        Dwarf_Signed fileCount = 0;
+        char** files = NULL;
+        Dwarf_Signed lineCount = 0;
+        Dwarf_Line *lines = NULL;
+        int lineIndex = 0;
+
+        res = dwarf_next_cu_header(debug, NULL, NULL, NULL, NULL, NULL, &error);
+        if (res != DW_DLV_OK) {
+            break;
+        }
+
+        res = dwarf_siblingof(debug, NULL, &cuDie, &error);
+        if (res != DW_DLV_OK) {
+            goto free_die;
+        }
+
+        res = dwarf_tag(cuDie, &tag, &error);
+        if (res != DW_DLV_OK) {
+            fprintf(stderr, "w2c2: failed to get DIE tag\n");
+            goto free_die;
+        }
+
+        if (tag != DW_TAG_compile_unit) {
+            fprintf(stderr, "w2c2: unexpected non-compile unit DIE tag: %d\n", tag);
+            goto free_die;
+        }
+
+        res = dwarf_srcfiles(cuDie, &files, &fileCount, &error);
+        if  (res != DW_DLV_OK) {
+            fprintf(stderr, "w2c2: failed to get CU DIE files\n");
+            goto free_die;
+        }
+
+        appendSubprogramDebugLines(debug, cuDie, files, &debugLines);
+
+        res = dwarf_srclines(cuDie, &lines, &lineCount, &error);
+        if (res != DW_DLV_OK) {
+            fprintf(stderr, "w2c2: failed to get lines\n");
+            goto free_files;
+        }
+
+        for (; lineIndex < lineCount; lineIndex++) {
+            Dwarf_Line line = lines[lineIndex];
+            WasmDebugLine debugLine = {0, NULL, 0};
+            char* path = NULL;
+
+            /* Line address */
+            res = dwarf_lineaddr(line, &debugLine.address, &error);
+            if (res != DW_DLV_OK) {
+                fprintf(stderr, "w2c2: failed to get line address\n");
+                goto loop_end;
+            }
+
+            /* TODO: why the big jump? */
+            if (debugLine.address >= 0xffffffff) {
+                continue;
+            }
+
+            /* Line source / path */
+            res = dwarf_linesrc(line, &path, &error);
+            if (res != DW_DLV_OK) {
+                fprintf(stderr, "w2c2: failed to get line source\n");
+                goto loop_end;
+            }
+            debugLine.path = strdup(path);
+            dwarf_dealloc(debug, path, DW_DLA_STRING);
+
+            /* Line number */
+            res = dwarf_lineno(line, &debugLine.number, &error);
+            if (res != DW_DLV_OK) {
+                fprintf(stderr, "w2c2: failed to get line number\n");
+                goto loop_end;
+            }
+
+            if (!wasmDebugLinesPush(&debugLines, debugLine)) {
+                goto loop_end;
+            }
+        }
+
+free_die:
+        dwarf_dealloc(debug, cuDie, DW_DLA_DIE);
+
+free_files:
+        {
+            int fileIndex = 0;
+            for (fileIndex = 0; fileIndex < fileCount; fileIndex++) {
+                dwarf_dealloc(debug, files[fileIndex], DW_DLA_STRING);
+            }
+        }
+        dwarf_dealloc(debug, files, DW_DLA_LIST);
+
+loop_end:
+        dwarf_srclines_dealloc(debug, lines, lineCount);
+    }
+
+    res = dwarf_object_finish(debug, &error);
+    if (res != DW_DLV_OK) {
+        fprintf(stderr, "w2c2: failed to finish DWARF reader\n");
+    }
+
+end:
+    if (interface != NULL) {
+        free(interface);
+    }
+
+    qsort(
+        debugLines.debugLines,
+        debugLines.length,
+        sizeof(WasmDebugLine),
+        compareDebugLines
+    );
+
+    return debugLines;
+}
+
+#else
+
+WasmDebugLines
+wasmParseDebugInfo(
+    WasmDebugSections sections
+) {
+    return emptyWasmDebugLines;
+}
+
+#endif

--- a/debug.h
+++ b/debug.h
@@ -1,0 +1,61 @@
+#ifndef W2C2_DEBUG_H
+#define W2C2_DEBUG_H
+
+#include "w2c2_base.h"
+#include "buffer.h"
+
+typedef struct WasmDebugSection {
+    char* name;
+    Buffer buffer;
+} WasmDebugSection;
+
+typedef struct WasmDebugSections {
+    WasmDebugSection* debugSections;
+    U32 count;
+    U32 capacity;
+} WasmDebugSections;
+
+typedef struct WasmDebugLine {
+    U64 address;
+    char *path;
+    U64 number;
+} WasmDebugLine;
+
+typedef struct WasmDebugLines {
+    WasmDebugLine* debugLines;
+    size_t length;
+    size_t capacity;
+} WasmDebugLines;
+
+static const WasmDebugLines emptyWasmDebugLines = {NULL, 0, 0};
+
+bool
+WARN_UNUSED_RESULT
+wasmDebugLinesEnsureCapacity(
+    WasmDebugLines* debugLines,
+    size_t length
+);
+
+static
+__inline__
+bool
+WARN_UNUSED_RESULT
+wasmDebugLinesPush(
+    WasmDebugLines* debugLines,
+    WasmDebugLine debugLine
+) {
+    const size_t newLength = debugLines->length + 1;
+    MUST (wasmDebugLinesEnsureCapacity(debugLines, newLength))
+
+    debugLines->debugLines[debugLines->length] = debugLine;
+    debugLines->length = newLength;
+
+    return true;
+}
+
+WasmDebugLines
+wasmParseDebugInfo(
+    WasmDebugSections sections
+);
+
+#endif /* W2C2_DEBUG_H */

--- a/examples/rust-wasi/Makefile
+++ b/examples/rust-wasi/Makefile
@@ -16,4 +16,4 @@ target/wasm32-wasi/debug/rust-wasi.wasm:
 
 .PHONY: clean
 clean:
-	rm -f target/wasm32-wasi/debug/rust-wasi.o *.o rust-wasi
+	rm -f target/wasm32-wasi/debug/rust-wasi.c target/wasm32-wasi/debug/rust-wasi.o *.o rust-wasi

--- a/function.h
+++ b/function.h
@@ -9,8 +9,11 @@ typedef struct WasmFunction {
     U32 functionTypeIndex;
     WasmLocalsDeclarations localsDeclarations;
     Buffer code;
+    /* Offset relative to the code section start (function count) */
+    U32 start;
 } WasmFunction;
 
-static const WasmFunction wasmEmptyFunction = {0, {NULL, 0}, {NULL, 0}};
+static const WasmFunction wasmEmptyFunction =
+    {0, {NULL, 0}, {NULL, 0}, 0};
 
 #endif /* W2C2_FUNCTION_H */

--- a/module.c
+++ b/module.c
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+#include "module.h"
+
+bool
+WARN_UNUSED_RESULT
+wasmDebugSectionsEnsureCapacity(
+    WasmDebugSections* debugSections,
+    size_t count
+) {
+    if (count > debugSections->capacity) {
+        size_t newCapacity = count + (debugSections->capacity >> 1u);
+        void* newDebugSections = NULL;
+        if (debugSections->debugSections == NULL) {
+            newDebugSections = calloc(newCapacity * sizeof(WasmDebugSection), 1);
+        } else {
+            newDebugSections = realloc(debugSections->debugSections, newCapacity * sizeof(WasmDebugSection));
+        }
+        MUST (newDebugSections != NULL)
+        debugSections->debugSections = (WasmDebugSection*) newDebugSections;
+        debugSections->capacity = newCapacity;
+    }
+    return true;
+}

--- a/module.h
+++ b/module.h
@@ -11,6 +11,7 @@
 #include "datasegment.h"
 #include "table.h"
 #include "elementsegment.h"
+#include "debug.h"
 
 typedef struct WasmFunctionTypes {
     WasmFunctionType* functionTypes;
@@ -53,6 +54,7 @@ typedef struct WasmElementSegments {
 } WasmElementSegments;
 
 typedef struct WasmModule {
+    size_t length;
     WasmFunctionTypes functionTypes;
     WasmFunctions functions;
     WasmExports exports;
@@ -67,6 +69,8 @@ typedef struct WasmModule {
     WasmElementSegments elementSegments;
     U32 startFunctionIndex;
     bool hasStartFunction;
+    WasmDebugSections debugSections;
+    WasmDebugLines debugLines;
 } WasmModule;
 
 static
@@ -137,6 +141,30 @@ wasmModuleGetFunctionType(
             *result = module->functionTypes.functionTypes[function.functionTypeIndex];
         }
     }
+    return true;
+}
+
+bool
+WARN_UNUSED_RESULT
+wasmDebugSectionsEnsureCapacity(
+    WasmDebugSections* debugSections,
+    size_t count
+);
+
+static
+__inline__
+bool
+WARN_UNUSED_RESULT
+wasmDebugSectionsAppend(
+    WasmDebugSections* debugSections,
+    WasmDebugSection debugSection
+) {
+    const size_t newCount = debugSections->count + 1;
+    MUST (wasmDebugSectionsEnsureCapacity(debugSections, newCount))
+
+    debugSections->debugSections[debugSections->count] = debugSection;
+    debugSections->count = newCount;
+
     return true;
 }
 

--- a/reader.h
+++ b/reader.h
@@ -5,7 +5,7 @@
 #include "buffer.h"
 #include "module.h"
 
-typedef struct {
+typedef struct WasmModuleReader {
     Buffer buffer;
     WasmModule* module;
 } WasmModuleReader;
@@ -19,6 +19,7 @@ typedef enum {
     wasmModuleReaderInvalidSectionSize,
     wasmModuleReaderIncorrectSectionRead,
     wasmModuleReaderInvalidCustomSectionName,
+    wasmModuleReaderDebugSectionAppendFailed,
     wasmModuleReaderInvalidTypeSectionTypeCount,
     wasmModuleReaderInvalidFunctionTypeIndicator,
     wasmModuleReaderInvalidFunctionTypeParameterCount,
@@ -71,6 +72,7 @@ wasmModuleReaderErrorMessage(
 void
 wasmModuleRead(
     WasmModuleReader* reader,
+    bool debug,
     WasmModuleReaderError** error
 );
 

--- a/str.h
+++ b/str.h
@@ -1,0 +1,15 @@
+#ifndef W2C2_STR_H
+#define W2C2_STR_H
+
+#include <string.h>
+#include <stdlib.h>
+
+char *strdup(const char *s) {
+    char *r = (char*) malloc(strlen(s) + 1);
+    if (r != NULL) {
+        strcpy(r, s);
+    }
+    return r;
+}
+
+#endif /* W2C2_STR_H */

--- a/tests/test.h
+++ b/tests/test.h
@@ -1,5 +1,5 @@
 #include "w2c2_base.h"
-    
+
 extern U32 *g_spectest_globalX5Fi32;
 extern U64 *g_spectest_globalX5Fi64;
 extern void (*f_spectest_print)(void);


### PR DESCRIPTION
Implement support for [DWARF in WebAssembly modules](https://yurydelendik.github.io/webassembly-dwarf/):

- Parse custom sections with `.debug_` prefix
- Parse DWARF information using `libdwarf`:
  - Line information of all compilation units
  - Line information of all subprograms
- Generate `#line` directives