### PR TITLE
fix signed char assumption

### DIFF
--- a/w2c2_base.h
+++ b/w2c2_base.h
@@ -13,7 +13,7 @@ typedef enum bool {
 #endif
 
 typedef unsigned char U8;
-typedef char I8;
+typedef signed char I8;
 
 typedef unsigned short U16;
 typedef short I16;


### PR DESCRIPTION
The C standard leaves the signedness of `char` undefined. As such, for example on ARM platforms, `char` is unsigned by default. This fixes the definition of the `I8` type to ensure that it is always signed, improving compatibility.