### PR TITLE
separate WARNS from CFLAGS so WARNS can be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,15 @@ ifndef UNAME
 	UNAME := $(shell uname -s)
 endif
 
+WARNS ?= -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function
+
 ifeq ($(BUILD),release)
 	CFLAGS += -O3
 else
 	CFLAGS += -g -O0
 endif
 
-CFLAGS += -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function
+CFLAGS += -std=c89 $(WARNS)
 
 ifeq ($(UNAME),Windows)
 	OUTPUT := w2c2.exe


### PR DESCRIPTION
I put the all the warning enablements into a separate variable so they could be overridden from the command prompt in case of needing to compile on an ancient version of GCC that doesn't support all of the warning types.  (Haiku x86 32-bit has a version of GCC11 patched for backward compatability with GCC2 that needs this.)