### PR TITLE
convert libwasi to libcwasi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ compile_flags.txt
 .DS_Store
 .idea
 cmake-build-debug
-
+*.a

--- a/examples/clang/Makefile
+++ b/examples/clang/Makefile
@@ -1,5 +1,5 @@
 CFLAGS += -I../..
-LDFLAGS += -lm -L../../wasi -lwasi
+LDFLAGS += -lm -L../../wasi -lcwasi
 W2C2 ?= ../../w2c2
 
 MODE := gnu-ld

--- a/examples/coremark/CMakeLists.txt
+++ b/examples/coremark/CMakeLists.txt
@@ -34,8 +34,8 @@ target_include_directories(coremark PUBLIC
 
 target_compile_options(coremark PUBLIC ${CFLAGS})
 
-find_library(WASI
-    NAMES wasi
+find_library(CWASI
+    NAMES cwasi
     PATHS ${CMAKE_CURRENT_SOURCE_DIR}/../../build
 )
-target_link_libraries(coremark PUBLIC ${WASI})
+target_link_libraries(coremark PUBLIC ${CWASI})

--- a/examples/coremark/Makefile
+++ b/examples/coremark/Makefile
@@ -1,4 +1,4 @@
-LDFLAGS += -lm -L../../wasi -lwasi
+LDFLAGS += -lm -L../../wasi -lcwasi
 CFLAGS += -O3
 W2C2 ?= ../../w2c2
 

--- a/examples/isatty/Makefile
+++ b/examples/isatty/Makefile
@@ -1,4 +1,4 @@
-LDFLAGS += -lm -L../../wasi -lwasi
+LDFLAGS += -lm -L../../wasi -lcwasi
 CFLAGS += -O3
 W2C2 ?= ../../w2c2
 

--- a/examples/ls/Makefile
+++ b/examples/ls/Makefile
@@ -1,4 +1,4 @@
-LDFLAGS += -lm -L../../wasi -lwasi
+LDFLAGS += -lm -L../../wasi -lcwasi
 CFLAGS += -O3
 W2C2 ?= ../../w2c2
 

--- a/examples/python/CMakeLists.txt
+++ b/examples/python/CMakeLists.txt
@@ -34,8 +34,8 @@ target_include_directories(python PUBLIC
 
 target_compile_options(python PUBLIC ${CFLAGS})
 
-find_library(WASI
-    NAMES wasi
+find_library(CWASI
+    NAMES cwasi
     PATHS ${CMAKE_CURRENT_SOURCE_DIR}/../../wasi/build
 )
-target_link_libraries(python PUBLIC ${WASI})
+target_link_libraries(python PUBLIC ${CWASI})

--- a/examples/python/Makefile
+++ b/examples/python/Makefile
@@ -1,5 +1,5 @@
 CFLAGS += -I../.. -O0 -g
-LDFLAGS += -lm -L../../wasi -lwasi
+LDFLAGS += -lm -L../../wasi -lcwasi
 W2C2 ?= ../../w2c2
 
 MODE := gnu-ld

--- a/examples/rust-wasi/CMakeLists.txt
+++ b/examples/rust-wasi/CMakeLists.txt
@@ -34,8 +34,8 @@ target_include_directories(rust-wasi PUBLIC
 
 target_compile_options(rust-wasi PUBLIC ${CFLAGS})
 
-find_library(WASI
-    NAMES wasi
+find_library(CWASI
+    NAMES cwasi
     PATHS ${CMAKE_CURRENT_SOURCE_DIR}/../../wasi/build
 )
-target_link_libraries(rust-wasi PUBLIC ${WASI})
+target_link_libraries(rust-wasi PUBLIC ${CWASI})

--- a/examples/rust-wasi/Makefile
+++ b/examples/rust-wasi/Makefile
@@ -1,5 +1,5 @@
 CFLAGS += -I../.. -O0 -g
-LDFLAGS += -lm -L../../wasi -lwasi
+LDFLAGS += -lm -L../../wasi -lcwasi
 W2C2 ?= ../../w2c2
 
 MODE := gnu-ld
@@ -35,4 +35,4 @@ target/wasm32-wasi/debug/rust-wasi.wasm:
 
 .PHONY: clean
 clean:
-	rm -f rust-wasi rustwasi.h $(filter-out main.c,$(wildcard *.c)) *.o
+	rm -f rust-wasi rustwasi.h $(filter-out main.c,$(wildcard *.c)) *.o datasegments

--- a/examples/swift-wasi/Makefile
+++ b/examples/swift-wasi/Makefile
@@ -1,5 +1,5 @@
 CFLAGS += -I../.. -O0 -g
-LDFLAGS += -lm -L../../wasi -lwasi
+LDFLAGS += -lm -L../../wasi -lcwasi
 W2C2 ?= ../../w2c2
 
 MODE := gnu-ld

--- a/wasi/CMakeLists.txt
+++ b/wasi/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
-project(wasi)
+project(cwasi)
 
 set(CMAKE_C_STANDARD 90)
 set(SHARED_LIB 0 CACHE BOOL "Build as a shared library")
@@ -32,52 +32,52 @@ FILE(GLOB TEST_SOURCES test.c *_test.c)
 list(REMOVE_ITEM SOURCES ${TEST_SOURCES})
 
 if (${SHARED_LIB})
-	add_library(wasi SHARED ${SOURCES})
+	add_library(cwasi SHARED ${SOURCES})
 else()
-	add_library(wasi STATIC ${SOURCES})
+	add_library(cwasi STATIC ${SOURCES})
 endif()
 
-target_compile_options(wasi PUBLIC
+target_compile_options(cwasi PUBLIC
     $<$<CXX_COMPILER_ID:MSVC>:/W4>
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Wunused-result -Wno-long-long -Wno-unused-function>
 )
 
 if(HAVE_UNISTD_H)
-    target_compile_definitions(wasi PUBLIC HAS_UNISTD=1)
+    target_compile_definitions(cwasi PUBLIC HAS_UNISTD=1)
 endif()
 
 if(HAVE_SYSUIO_H)
-    target_compile_definitions(wasi PUBLIC HAS_SYSUIO=1)
+    target_compile_definitions(cwasi PUBLIC HAS_SYSUIO=1)
 endif()
 
 if(HAVE_SYSTIME_H)
-    target_compile_definitions(wasi PUBLIC HAS_SYSTIME=1)
+    target_compile_definitions(cwasi PUBLIC HAS_SYSTIME=1)
 endif()
 
 if(HAVE_SYSRESOURCE_H)
-    target_compile_definitions(wasi PUBLIC HAS_SYSRESOURCE=1)
+    target_compile_definitions(cwasi PUBLIC HAS_SYSRESOURCE=1)
 endif()
 
 if(HAVE_STRNDUP)
-    target_compile_definitions(wasi PUBLIC HAS_STRNDUP=1)
+    target_compile_definitions(cwasi PUBLIC HAS_STRNDUP=1)
 endif()
 
 if(HAVE_FCNTL)
-    target_compile_definitions(wasi PUBLIC HAS_FCNTL=1)
+    target_compile_definitions(cwasi PUBLIC HAS_FCNTL=1)
 endif()
 
 if(HAVE_LSTAT)
-    target_compile_definitions(wasi PUBLIC HAS_LSTAT=1)
+    target_compile_definitions(cwasi PUBLIC HAS_LSTAT=1)
 endif()
 
 if(HAVE_GETENTROPY)
-    target_compile_definitions(wasi PUBLIC HAS_GETENTROPY=1)
+    target_compile_definitions(cwasi PUBLIC HAS_GETENTROPY=1)
 endif()
 
 if(HAVE_TIMESPEC)
-    target_compile_definitions(wasi PUBLIC HAS_TIMESPEC=1)
+    target_compile_definitions(cwasi PUBLIC HAS_TIMESPEC=1)
 endif()
 
 if(MSVC)
-    target_compile_definitions(wasi PUBLIC _CRT_SECURE_NO_DEPRECATE)
+    target_compile_definitions(cwasi PUBLIC _CRT_SECURE_NO_DEPRECATE)
 endif()

--- a/wasi/Makefile
+++ b/wasi/Makefile
@@ -78,7 +78,7 @@ OBJECTS = $(patsubst %.c,%.o,$(filter-out test.c,$(wildcard *.c)))
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
-libwasi.a: $(OBJECTS)
+libcwasi.a: $(OBJECTS)
 	$(AR) rcu $@ $^
 	ranlib $@
 


### PR DESCRIPTION
Since Python created with C is CPython, I figured CWASI is WASI created with C.  Further addresses #39 by renaming libwasi.so to libcwasi.so as well.