### PR TITLE
Enable use as CMake subdirectory

### DIFF
--- a/w2c2/CMakeLists.txt
+++ b/w2c2/CMakeLists.txt
@@ -11,9 +11,11 @@ set(CMAKE_C_STANDARD 90)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads)
 
-find_package(PkgConfig)
-if(PKG_CONFIG_FOUND)
-    pkg_check_modules(DWARF libdwarf)
+if(NOT DWARF_FOUND)
+    find_package(PkgConfig)
+    if(PKG_CONFIG_FOUND)
+        pkg_check_modules(DWARF libdwarf)
+    endif()
 endif()
 
 include(CheckIncludeFile)
@@ -33,7 +35,7 @@ list(REMOVE_ITEM SOURCES ${TEST_SOURCES})
 
 add_executable(w2c2 ${SOURCES})
 
-list(REMOVE_ITEM SOURCES ${CMAKE_SOURCE_DIR}/main.c)
+list(REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/main.c)
 add_executable(test ${TEST_SOURCES} ${SOURCES})
 
 foreach(TARGET w2c2 test)


### PR DESCRIPTION
Few changes to allow the project to be used with `add_subdirectory()`.

1. use `CMAKE_CURRENT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR`
2. if `libdwarf` is a sibling, allow the parent `CMakeLists.txt` to `set(DWARF_LIBRARIES dwarf-static)` and `set(DWARF_FOUND TRUE)` avoiding PkgConfig in that situation.