### PR TITLE
Add an option to link against imports

### DIFF
--- a/w2c2/c.c
+++ b/w2c2/c.c
@@ -4495,11 +4495,11 @@ wasmCWriteModuleDeclarations(
     bool debug,
     bool linkImports
 ) {
+    wasmCWriteModuleInstanceDeclaration(file, module, moduleName, pretty, linkImports);
     /* If linkImports is true, then the function imports are not part of the instance struct */
     if (linkImports) {
         wasmCWriteFunctionImports(file, module, moduleName, pretty, true);
     }
-    wasmCWriteModuleInstanceDeclaration(file, module, moduleName, pretty, linkImports);
     wasmCWriteFunctionDeclarations(file, module, moduleName, pretty, debug);
     wasmCWriteExports(file, module, moduleName, false, pretty, linkImports);
 }

--- a/w2c2/c.h
+++ b/w2c2/c.h
@@ -10,11 +10,12 @@ typedef struct WasmCWriteModuleOptions {
     U32 functionsPerFile;
     bool pretty;
     bool debug;
+    bool linkImports;
     WasmDataSegmentMode dataSegmentMode;
 } WasmCWriteModuleOptions;
 
 static const WasmCWriteModuleOptions emptyWasmCWriteModuleOptions ={
-    NULL, 0, 0, false, false, wasmDataSegmentModeArrays
+    NULL, 0, 0, false, false, false, wasmDataSegmentModeArrays
 };
 
 bool

--- a/w2c2/main.c
+++ b/w2c2/main.c
@@ -22,9 +22,9 @@
 #include "stringbuilder.h"
 
 #if HAS_PTHREAD
-static char* const optString = "t:f:d:pgh";
+static char* const optString = "t:f:d:pglh";
 #else
-static char* const optString = "f:d:pgh";
+static char* const optString = "f:d:pglh";
 #endif /* HAS_PTHREAD */
 
 static
@@ -93,6 +93,7 @@ main(
     U32 functionsPerFile = 0;
     bool pretty = false;
     bool debug = false;
+    bool linkImports = false;
     WasmDataSegmentMode dataSegmentMode = wasmDataSegmentModeArrays;
     char moduleName[PATH_MAX];
 
@@ -119,6 +120,10 @@ main(
             }
             case 'g': {
                 debug = true;
+                break;
+            }
+            case 'l': {
+                linkImports = true;
                 break;
             }
             case 'd': {
@@ -174,6 +179,7 @@ main(
                     "  -d MODE    Data segment mode. Default: arrays. Use 'help' to print available modes\n"
                     "  -g         Generate debug information (function names using asm(); #line directives based on DWARF, if available)\n"
                     "  -p         Generate pretty code\n"
+                    "  -l         Link against imported functions rather than resolving them at runtime\n"
                 );
                 return 0;
             }
@@ -249,6 +255,7 @@ main(
         writeOptions.functionsPerFile = functionsPerFile;
         writeOptions.pretty = pretty;
         writeOptions.debug = debug;
+        writeOptions.linkImports = linkImports;
         writeOptions.dataSegmentMode = dataSegmentMode;
 
         if (!wasmCWriteModule(reader.module, moduleName, writeOptions)) {


### PR DESCRIPTION
Closes #59

Add a `-l` option to link against imports directly. This should improve performance by removing a layer of indirection and allowing link-time-optimisation to do its magic. This is important in my case because I want to import functions that set individual pixels in a framebuffer so it needs to be inlined and fast. I haven't thoroughly tested this but it works from some basic testing.

(is "link against" the right term here? w2c2 doesn't do any linking by itself but I mean that module is written in a way that it expects to linked against the imports)