### PR TITLE
Option to pass alignment hints to the load and store macros

### DIFF
--- a/w2c2/c.h
+++ b/w2c2/c.h
@@ -11,11 +11,12 @@ typedef struct WasmCWriteModuleOptions {
     bool pretty;
     bool debug;
     bool linkImports;
+    bool writeAlignment;
     WasmDataSegmentMode dataSegmentMode;
 } WasmCWriteModuleOptions;
 
 static const WasmCWriteModuleOptions emptyWasmCWriteModuleOptions ={
-    NULL, 0, 0, false, false, false, wasmDataSegmentModeArrays
+    NULL, 0, 0, false, false, false, false, wasmDataSegmentModeArrays
 };
 
 bool

--- a/w2c2/instruction.c
+++ b/w2c2/instruction.c
@@ -1,4 +1,5 @@
 #include "instruction.h"
+#include <stdio.h>
 
 /* WasmLocalInstruction */
 
@@ -72,7 +73,7 @@ wasmLoadStoreInstructionRead(
     MUST (leb128ReadU32(buffer, &offset) > 0)
 
     result->opcode = opcode;
-    result->align = align;
+    result->align = 1 << align;
     result->offset = offset;
 
     return true;

--- a/w2c2/main.c
+++ b/w2c2/main.c
@@ -22,9 +22,9 @@
 #include "stringbuilder.h"
 
 #if HAS_PTHREAD
-static char* const optString = "t:f:d:pglh";
+static char* const optString = "t:f:d:pglah";
 #else
-static char* const optString = "f:d:pglh";
+static char* const optString = "f:d:pglah";
 #endif /* HAS_PTHREAD */
 
 static
@@ -94,6 +94,7 @@ main(
     bool pretty = false;
     bool debug = false;
     bool linkImports = false;
+    bool writeAlignment = false;
     WasmDataSegmentMode dataSegmentMode = wasmDataSegmentModeArrays;
     char moduleName[PATH_MAX];
 
@@ -124,6 +125,10 @@ main(
             }
             case 'l': {
                 linkImports = true;
+                break;
+            }
+            case 'a': {
+                writeAlignment = true;
                 break;
             }
             case 'd': {
@@ -180,6 +185,7 @@ main(
                     "  -g         Generate debug information (function names using asm(); #line directives based on DWARF, if available)\n"
                     "  -p         Generate pretty code\n"
                     "  -l         Link against imported functions rather than resolving them at runtime\n"
+                    "  -a         Pass alsignment hints to the load and store macros. You'll need a custom w2c2_base.h to use this\n"
                 );
                 return 0;
             }
@@ -259,6 +265,7 @@ main(
         writeOptions.pretty = pretty;
         writeOptions.debug = debug;
         writeOptions.linkImports = linkImports;
+        writeOptions.writeAlignment = writeAlignment;
         writeOptions.dataSegmentMode = dataSegmentMode;
 
         if (!wasmCWriteModule(reader.module, moduleName, writeOptions)) {


### PR DESCRIPTION
This won't work with the original `w2c2_base.h`, but a custom one should be able to make use of it.

Questions:
- Should I validate whether the hints have valid values, or just assume it's valid like I am now?
- Should I be doing `result->align = 1 << align;` in the instruction reader like I have here, leave it as-is in the instruction struct and do that as the C source file is written, or write it to the file as-is and have the macros do it?