### PR TITLE
Fix allocation of function names

### DIFF
--- a/w2c2/reader.c
+++ b/w2c2/reader.c
@@ -447,6 +447,14 @@ wasmReadNameSection(
                     return;
                 }
 
+                if (functionIndex >= functionCount) {
+                    static WasmModuleReaderError wasmModuleReaderError = {
+                        wasmModuleReaderInvalidNameSectionFunctionIndex
+                    };
+                    *error = &wasmModuleReaderError;
+                    return;
+                }
+
                 /* Read function name */
                 if (!wasmReadName(&reader->buffer, &functionName)) {
                     static WasmModuleReaderError wasmModuleReaderError = {

--- a/w2c2/reader.c
+++ b/w2c2/reader.c
@@ -402,7 +402,9 @@ wasmReadNameSection(
 
         /* Read function names */
         if (subsectionID == wasmNameSubsectionIDFunctionNames) {
-            const U32 functionCount = reader->module->functions.count;
+            const U32 functionCount = 
+                reader->module->functionImports.length 
+                + reader->module->functions.count;
 
             U32 functionNameIndex = 0;
 


### PR DESCRIPTION
Closes #70

Imports may also be named, so allocate space for their names too