### PR TITLE
Make WASI and w2c2_base.h compile on MSVC 4.0

### DIFF
--- a/w2c2/c.c
+++ b/w2c2/c.c
@@ -1045,8 +1045,9 @@ wasmCWriteLiteral(
             break;
         }
         case wasmValueTypeI64: {
+            MUST (stringBuilderAppend(builder, "W2C2_LL("))
             MUST (stringBuilderAppendI64(builder, value.i64))
-            MUST (stringBuilderAppend(builder, "ULL"))
+            MUST (stringBuilderAppend(builder, "U)"))
             break;
         }
         case wasmValueTypeF32: {

--- a/w2c2/w2c2_base.h
+++ b/w2c2/w2c2_base.h
@@ -5,7 +5,7 @@
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>
-#ifndef __NeXT__
+#if !(defined(__NeXT__) || (defined(_MSC_VER) && _MSC_VER <= 1000))
 #include <stdint.h>
 #endif
 
@@ -35,8 +35,13 @@ typedef signed short I16;
 typedef unsigned int U32;
 typedef signed int I32;
 
+#if defined(_MSC_VER) && _MSC_VER <= 1000
+typedef unsigned __int64 U64;
+typedef signed __int64 I64;
+#else
 typedef unsigned long long int U64;
 typedef signed long long int I64;
+#endif
 
 typedef float F32;
 typedef double F64;
@@ -185,6 +190,12 @@ typedef double F64;
 #define UNUSED
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER <= 1000
+#define LLONG_MIN (-0x7fffffffffffffffi64-1)
+#define LLONG_MAX 0x7fffffffffffffffi64
+#define INT64_MAX 9223372036854775807i64
+#define UINT64_MAX 18446744073709551615Ui64
+#else /* defined(_MSC_VER) && _MSC_VER <= 1000 */
 #ifndef LLONG_MIN
 #define LLONG_MIN (-0x7fffffffffffffffLL-1)
 #endif
@@ -192,6 +203,15 @@ typedef double F64;
 #ifndef LLONG_MAX
 #define LLONG_MAX 0x7fffffffffffffffLL
 #endif
+
+#ifndef INT64_MAX
+#define INT64_MAX 9223372036854775807LL
+#endif
+
+#ifndef UINT64_MAX
+#define UINT64_MAX 18446744073709551615ULL
+#endif
+#endif /* defined(_MSC_VER) && _MSC_VER <= 1000 */
 
 #ifndef INT32_MAX
 #define INT32_MAX 2147483647
@@ -201,10 +221,6 @@ typedef double F64;
 #define INT32_MIN (-INT32_MAX - 1)
 #endif
 
-#ifndef INT64_MAX
-#define INT64_MAX 9223372036854775807LL
-#endif
-
 #ifndef INT64_MIN
 #define INT64_MIN (-INT64_MAX - 1)
 #endif
@@ -212,11 +228,6 @@ typedef double F64;
 #ifndef UINT32_MAX
 #define UINT32_MAX 4294967295U
 #endif
-
-#ifndef UINT64_MAX
-#define UINT64_MAX 18446744073709551615ULL
-#endif
-
 #if defined(_MSC_VER) && _MSC_VER <= 1500
 
 /* disable warning C4756: overflow in constant arithmetic */
@@ -341,10 +352,17 @@ I32_POPCNT(
 static
 W2C2_INLINE
 U64 I64_POPCNT(U64 x) {
+#if defined(_MSC_VER) && _MSC_VER <= 1000
+    x -= ((x >> 1) & 0x5555555555555555ui64);
+    x = ((x >> 2) & 0x3333333333333333ui64) + (x & 0x3333333333333333ui64);
+    x = ((x >> 4) + x) & 0xf0f0f0f0f0f0f0fui64;
+    x *= 0x101010101010101ui64;
+#else
     x -= ((x >> 1) & 0x5555555555555555ull);
     x = ((x >> 2) & 0x3333333333333333ull) + (x & 0x3333333333333333ull);
     x = ((x >> 4) + x) & 0xf0f0f0f0f0f0f0full;
     x *= 0x101010101010101ull;
+#endif
     return (x >> 56);
 }
 #endif
@@ -1049,8 +1067,13 @@ DEFINE_SWAP(32, i, int)
 DEFINE_SWAP(32, I, unsigned int)
 DEFINE_SWAP(32, l, long)
 DEFINE_SWAP(32, L, unsigned long)
+#if defined(_MSC_VER) && _MSC_VER <= 1000
+DEFINE_SWAP(64, q, signed __int64)
+DEFINE_SWAP(64, Q, unsigned __int64)
+#else
 DEFINE_SWAP(64, q, long long)
 DEFINE_SWAP(64, Q, unsigned long long)
+#endif
 DEFINE_SWAP(32, f, float)
 DEFINE_SWAP(64, d, double)
 
@@ -1110,7 +1133,7 @@ typedef struct wasmModuleInstance {
 #define __has_extension __has_feature
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER >= 1500
 #define WASM_ATOMICS_MSVC
 #elif defined(__GNUC__) && (GCC_VERSION >= 40700 || __has_extension(c_atomic))
 #define WASM_ATOMICS_GCC

--- a/w2c2/w2c2_base.h
+++ b/w2c2/w2c2_base.h
@@ -46,6 +46,12 @@ typedef signed long long int I64;
 typedef float F32;
 typedef double F64;
 
+#if defined(_MSC_VER) && _MSC_VER <= 1000
+#define W2C2_LL(x) x ## i64
+#else
+#define W2C2_LL(x) x ## ll
+#endif
+
 #define MUST(_) { if (!(_)) { return false; }; }
 
 #define WASM_LITTLE_ENDIAN  0
@@ -149,14 +155,14 @@ typedef double F64;
                   | (((x) & 0x00FF0000) >> 8 ) \
                   | (((x) & 0x0000FF00) << 8 ) \
                   | (((x) & 0x000000FF) << 24))
-#define swapU64(x) ((((x) & 0xff00000000000000ull) >> 56) \
-                  | (((x) & 0x00ff000000000000ull) >> 40) \
-                  | (((x) & 0x0000ff0000000000ull) >> 24) \
-                  | (((x) & 0x000000ff00000000ull) >> 8 ) \
-                  | (((x) & 0x00000000ff000000ull) << 8 ) \
-                  | (((x) & 0x0000000000ff0000ull) << 24) \
-                  | (((x) & 0x000000000000ff00ull) << 40) \
-                  | (((x) & 0x00000000000000ffull) << 56))
+#define swapU64(x) ((((x) & W2C2_LL(0xff00000000000000u)) >> 56) \
+                  | (((x) & W2C2_LL(0x00ff000000000000u)) >> 40) \
+                  | (((x) & W2C2_LL(0x0000ff0000000000u)) >> 24) \
+                  | (((x) & W2C2_LL(0x000000ff00000000u)) >> 8 ) \
+                  | (((x) & W2C2_LL(0x00000000ff000000u)) << 8 ) \
+                  | (((x) & W2C2_LL(0x0000000000ff0000u)) << 24) \
+                  | (((x) & W2C2_LL(0x000000000000ff00u)) << 40) \
+                  | (((x) & W2C2_LL(0x00000000000000ffu)) << 56))
 
 #endif
 
@@ -190,28 +196,13 @@ typedef double F64;
 #define UNUSED
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER <= 1000
-#define LLONG_MIN (-0x7fffffffffffffffi64-1)
-#define LLONG_MAX 0x7fffffffffffffffi64
-#define INT64_MAX 9223372036854775807i64
-#define UINT64_MAX 18446744073709551615Ui64
-#else /* defined(_MSC_VER) && _MSC_VER <= 1000 */
 #ifndef LLONG_MIN
-#define LLONG_MIN (-0x7fffffffffffffffLL-1)
+#define LLONG_MIN (W2C2_LL(-0x7fffffffffffffff)-1)
 #endif
 
 #ifndef LLONG_MAX
-#define LLONG_MAX 0x7fffffffffffffffLL
+#define LLONG_MAX W2C2_LL(0x7fffffffffffffff)
 #endif
-
-#ifndef INT64_MAX
-#define INT64_MAX 9223372036854775807LL
-#endif
-
-#ifndef UINT64_MAX
-#define UINT64_MAX 18446744073709551615ULL
-#endif
-#endif /* defined(_MSC_VER) && _MSC_VER <= 1000 */
 
 #ifndef INT32_MAX
 #define INT32_MAX 2147483647
@@ -221,6 +212,10 @@ typedef double F64;
 #define INT32_MIN (-INT32_MAX - 1)
 #endif
 
+#ifndef INT64_MAX
+#define INT64_MAX W2C2_LL(9223372036854775807)
+#endif
+
 #ifndef INT64_MIN
 #define INT64_MIN (-INT64_MAX - 1)
 #endif
@@ -228,6 +223,11 @@ typedef double F64;
 #ifndef UINT32_MAX
 #define UINT32_MAX 4294967295U
 #endif
+
+#ifndef UINT64_MAX
+#define UINT64_MAX W2C2_LL(18446744073709551615U)
+#endif
+
 #if defined(_MSC_VER) && _MSC_VER <= 1500
 
 /* disable warning C4756: overflow in constant arithmetic */
@@ -352,17 +352,10 @@ I32_POPCNT(
 static
 W2C2_INLINE
 U64 I64_POPCNT(U64 x) {
-#if defined(_MSC_VER) && _MSC_VER <= 1000
-    x -= ((x >> 1) & 0x5555555555555555ui64);
-    x = ((x >> 2) & 0x3333333333333333ui64) + (x & 0x3333333333333333ui64);
-    x = ((x >> 4) + x) & 0xf0f0f0f0f0f0f0fui64;
-    x *= 0x101010101010101ui64;
-#else
-    x -= ((x >> 1) & 0x5555555555555555ull);
-    x = ((x >> 2) & 0x3333333333333333ull) + (x & 0x3333333333333333ull);
-    x = ((x >> 4) + x) & 0xf0f0f0f0f0f0f0full;
-    x *= 0x101010101010101ull;
-#endif
+    x -= ((x >> 1) & W2C2_LL(0x5555555555555555u));
+    x = ((x >> 2) & W2C2_LL(0x3333333333333333u)) + (x & W2C2_LL(0x3333333333333333u));
+    x = ((x >> 4) + x) & W2C2_LL(0xf0f0f0f0f0f0f0fu);
+    x *= W2C2_LL(0x101010101010101u);
     return (x >> 56);
 }
 #endif

--- a/wasi/wasi.c
+++ b/wasi/wasi.c
@@ -1666,18 +1666,10 @@ WASI_IMPORT(U32, fd_close, (
 })
 
 #ifndef NSEC_PER_SEC
-#if defined(_MSC_VER) && _MSC_VER <= 1000
-#define NSEC_PER_SEC 1000000000i64
-#else
-#define NSEC_PER_SEC 1000000000LL
-#endif
+#define NSEC_PER_SEC W2C2_LL(1000000000)
 #endif
 #ifndef NSEC_PER_USEC
-#if defined(_MSC_VER) && _MSC_VER <= 1000
-#define NSEC_PER_USEC 1000i64
-#else
-#define NSEC_PER_USEC 1000LL
-#endif
+#define NSEC_PER_USEC W2C2_LL(1000)
 #endif
 
 static

--- a/wasi/wasi.c
+++ b/wasi/wasi.c
@@ -10,8 +10,12 @@
 #endif /* HAS_UNISTD */
 
 #ifdef _MSC_VER
+#if _MSC_VER <= 1000
+typedef signed int ssize_t; /* assuming target machine is ILP32 ! */
+#else
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
+#endif
 #define INT64_C(val) val##i64
 #endif /* _MSC_VER */
 
@@ -1662,10 +1666,18 @@ WASI_IMPORT(U32, fd_close, (
 })
 
 #ifndef NSEC_PER_SEC
+#if defined(_MSC_VER) && _MSC_VER <= 1000
+#define NSEC_PER_SEC 1000000000i64
+#else
 #define NSEC_PER_SEC 1000000000LL
 #endif
+#endif
 #ifndef NSEC_PER_USEC
+#if defined(_MSC_VER) && _MSC_VER <= 1000
+#define NSEC_PER_USEC 1000i64
+#else
 #define NSEC_PER_USEC 1000LL
+#endif
 #endif
 
 static
@@ -3901,7 +3913,7 @@ wasiRandomGet(
 
     bufferStart = memory->data + bufferPointer;
 
-#ifdef _WIN32
+#if defined(_WIN32) && !(defined(_MSC_VER) && _MSC_VER <= 1000)
 #include <wincrypt.h>
     {
         HCRYPTPROV provider;
@@ -3970,7 +3982,7 @@ wasiRandomGet(
             return WASI_ERRNO_SUCCESS;
         }
     }
-#if defined(__MWERKS__) && defined(macintosh)
+#if (defined(__MWERKS__) && defined(macintosh)) || (defined(_MSC_VER) && _MSC_VER <= 1000)
     /* Fall back to rand */
     {
         U32 i = 0;

--- a/wasi/win32.h
+++ b/wasi/win32.h
@@ -8,6 +8,27 @@
 extern "C" {
 #endif
 
+/* defines for MSVC 4.0 */
+#ifndef ERROR_DELETE_PENDING
+#define ERROR_DELETE_PENDING 303
+#endif
+
+#ifndef ERROR_CANT_RESOLVE_FILENAME
+#define ERROR_CANT_RESOLVE_FILENAME 1921
+#endif
+
+#ifndef INVALID_FILE_ATTRIBUTES
+#define INVALID_FILE_ATTRIBUTES (~0u)
+#endif
+
+#ifndef FILE_ATTRIBUTE_REPARSE_POINT
+#define FILE_ATTRIBUTE_REPARSE_POINT 0x00000400
+#endif
+
+#ifndef IO_REPARSE_TAG_MOUNT_POINT
+#define IO_REPARSE_TAG_MOUNT_POINT 0xA0000003l
+#endif
+
 struct dirent {
     long d_ino;
     unsigned short d_reclen;


### PR DESCRIPTION
Why MSVC 4.0 specifically? Mostly because it's the only compiler that I'm aware of that can target the RISC versions of Windows NT 4.0 (yes, there were official versions for MIPS, PowerPC and Alpha).

~~Generated code will still not compile with it though, as there's no `long long` type in MSVC4. You can replace all `LL` suffixes with `i64` though, around c.c:1049:~~
https://github.com/turbolent/w2c2/blob/22a9adeef081714e0d07ea62aa0ec734c6a5f99f/w2c2/c.c#L1047-L1050

~~The only reason that I didn't include it in this PR is that I wasn't able to find a way to add a type toggle switch while making the code pretty.~~ (UPDATE: Made a `W2C2_LL` macro, no need for this anymore.)

There's still stuff to do to get the generated code to work completely with MSVC4, such as finding workarounds to the following errors:
* `error C2520: conversion from unsigned __int64 to double not implemented, use signed __int64`
* `fatal error C1053: 'fXXXX' : function too large`

Also, while not exactly fatal, the endianness check fails on MIPS for some reason (untested on PowerPC and Alpha).

Those errors come from the Python example, although I was able to get the ls and Rust examples working from the current patches.