### PR TITLE
WASI: Fix length of prestat path

### DIFF
--- a/wasi/wasi.c
+++ b/wasi/wasi.c
@@ -2417,7 +2417,7 @@ WASI_IMPORT(U32, fd_prestat_get, (
         return WASI_ERRNO_BADF;
     }
 
-    length = strlen(path) + 1;
+    length = strlen(path);
     i32_store(memory, prestatPointer, WASI_PREOPEN_TYPE_DIRECTORY);
     i32_store(memory, prestatPointer + 4, length);
 
@@ -2462,7 +2462,7 @@ wasiFdPrestatDirName(
         return WASI_ERRNO_BADF;
     }
 
-    length = strlen(path) + 1;
+    length = strlen(path);
     if (length >= pathLength) {
         length = pathLength;
     }


### PR DESCRIPTION
Path should not be null-terminated. Discovered by running the Go compiler and comparing with wasmtime