### PR TITLE
Prevent loops from being optimized out when compiled as C++

### DIFF
--- a/w2c2/w2c2_base.h
+++ b/w2c2/w2c2_base.h
@@ -52,12 +52,13 @@ typedef double F64;
 #define W2C2_LL(x) x ## ll
 #endif
 
-/* Prevent LLVM/Clang >=12 from optimizing away infinite loops */
-#if defined(__clang__) && __clang_major__ >= 12
+/* Prevent infinite loops from being optimized out when compiled as C++ */
+#ifdef __cplusplus
 #define W2C2_LOOP_START __asm__ volatile("");
 #else
 #define W2C2_LOOP_START
 #endif
+
 #define MUST(_) { if (!(_)) { return false; }; }
 
 #define WASM_LITTLE_ENDIAN  0


### PR DESCRIPTION
Follow-up to #121, see https://github.com/turbolent/w2c2/pull/121#issuecomment-3094625139