### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,7 +185,7 @@ jobs:
         run: make test BUILD=${{ matrix.build }} FEATURES="unistd sysuio systime sysresource strndup fcntl timespec lstat pthreads"
 
   windows-msvc:
-    runs-on: windows-2019
+    runs-on: windows-latest
     name: "Windows (MSVC)"
 
     steps:


### PR DESCRIPTION
use `windows-latest`, `windows-2019` got removed