### PR TITLE
Improve clang example

### DIFF
--- a/examples/clang/.gitignore
+++ b/examples/clang/.gitignore
@@ -1,5 +1,4 @@
 [0-9]*.c
 clang.h
 clang.c
-clang
 datasegments

--- a/examples/clang/README.md
+++ b/examples/clang/README.md
@@ -2,7 +2,13 @@
 
 `llvm.wasm` is LLVM/Clang built as a WebAssembly WASI binary,
 from https://github.com/YoWASP/clang/commit/3aa8abe1f0146bb9c0fe9191bd72d0fab06e4eb0,
-which is a project by https://github.com/whitequark
+which is a project by https://github.com/whitequark.
+
+It was optimized with Binaryen:
+
+```sh
+$ wasm-opt --enable-bulk-memory --enable-nontrapping-float-to-int -O4 -o llvm.opt.wasm llvm.wasm
+```
 
 ## Build
 
@@ -13,6 +19,8 @@ make -j12
 ## Usage
 
 ```sh
-echo 'int printf(const char *, ...); int main(){ printf("hello world"); }' > hello.c
-./sys/bin/clang -o `pwd`/hello.o `pwd`/hello.c
+$ echo 'int printf(const char *, ...); int main(){ printf("Hello, world!"); }' > hello.c
+$ ./sys/bin/clang -o `pwd`/hello.wasm `pwd`/hello.c
+$ wasmtime ./hello.wasm
+Hello, world!
 ```

--- a/examples/clang/Submake
+++ b/examples/clang/Submake
@@ -7,7 +7,5 @@ sys/bin/llvm: llvm.o
 datasegments.o: llvm.c
 	ld -r -b binary -o datasegments.o datasegments
 
-llvm.o: CFLAGS += -O3
-
 %.o: %.c
-	$(CC) -I.. -O3 $(CFLAGS) -c $< -o $@
+	$(CC) -I.. $(CFLAGS) -c $< -o $@

--- a/examples/clang/sys/bin/clang
+++ b/examples/clang/sys/bin/clang
@@ -1,0 +1,1 @@
+driverdriver.py


### PR DESCRIPTION
The original `llvm.wasm` contained functions with massively nested blocks (thousands) which caused stack overflows on some systems